### PR TITLE
Protexer a configuración local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,10 @@ client/.dart_tool/
 client/build/
 client/.flutter-plugins
 
+# Local Firebase configuration
+client/ios/Runner/GoogleService-Info.plist
+client/android/app/google-services.json
+
+# Generated Android reports
+client/android/build/reports/
+


### PR DESCRIPTION
Resumo

- Corrixe as rutas dos ficheiros locais de Firebase.
- Exclúe o informe xerado por Android.
- Mantén estes ficheiros fóra dos commits.

Comprobacións

- Git confirma que os tres ficheiros quedan ignorados.
- O commit só contén o cambio de .gitignore.

Closes #44
Refs #22