### PR TITLE
[API] Endereitar imaxes antes do OCR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ client/android/app/google-services.json
 # Generated Android reports
 client/android/build/reports/
 
+# Temporary image preprocessing diagnostics
+server/tmp/preprocesamento/
+

--- a/server/app/internal/preprocesamento.py
+++ b/server/app/internal/preprocesamento.py
@@ -20,8 +20,11 @@ MAX_DIMENSION_DETECCION = 1600
 MIN_DIMENSION_IMAXE = 160
 MIN_AREA_FOLLA = 0.38
 MAX_AREA_FOLLA = 0.96
-MIN_ANGULO_CORRECCION = 0.7
-MAX_ANGULO_CORRECCION = 15.0
+MIN_AREA_FOLLA_CLARA = 0.24
+MAX_AREA_FOLLA_CLARA = 0.82
+MIN_ANGULO_CORRECCION = 1.0
+MAX_ANGULO_PERSPECTIVA = 15.0
+MAX_ANGULO_INCLINACION = 30.0
 MAX_PIXELES_PREPROCESAMENTO = 30_000_000
 MAX_LADO_AZURE = 10_000
 MAX_BYTES_PREDETERMINADOS = 3_900_000
@@ -71,9 +74,6 @@ def preprocesar_documento(
     if tipo and not (tipo.startswith("image/") or tipo == "application/octet-stream"):
         return _sen_cambios(contido, "tipo_non_soportado")
 
-    if len(contido) > _limite_bytes_saida():
-        return _sen_cambios(contido, "ficheiro_supera_limite_preprocesamento")
-
     try:
         datos = np.frombuffer(contido, dtype=np.uint8)
         imaxe = cv2.imdecode(datos, cv2.IMREAD_COLOR)
@@ -103,11 +103,31 @@ def preprocesar_documento(
             if resultado is not None:
                 return resultado
 
+        # Nunha fotografía real os bordos do papel poden ser suaves ou quedar
+        # interrompidos por sombras. Como segunda vía búscase unha superficie
+        # clara, pouco saturada e cunha xeometría compatible cunha folla. Esta
+        # detección mantén requisitos de bordo e contraste para non confundir
+        # unha zona branca da propia impresión coa silueta exterior.
+        candidato_claro = _buscar_folla_clara(imaxe_deteccion, gris, bordos)
+        if candidato_claro is not None:
+            cuadrilatero, confianza = candidato_claro
+            resultado = _corrixir_perspectiva(
+                contido,
+                imaxe,
+                cuadrilatero / escala,
+                confianza,
+                tipo,
+                motivo="silueta_clara_da_folla",
+                max_angulo=MAX_ANGULO_INCLINACION,
+            )
+            if resultado is not None:
+                return resultado
+
         correccion = _estimar_inclinacion(bordos)
         if correccion is None:
             return _sen_cambios(contido, "deteccion_sen_confianza", dimensions)
 
-        angulo, confianza = correccion
+        angulo, confianza, puntos_linas = correccion
         if abs(angulo) < MIN_ANGULO_CORRECCION:
             return _sen_cambios(contido, "imaxe_xa_recta", dimensions)
 
@@ -117,7 +137,11 @@ def preprocesar_documento(
             or ancho_rotada * alto_rotada > MAX_PIXELES_PREPROCESAMENTO
         ):
             return _sen_cambios(contido, "saida_supera_limite_de_dimensions", dimensions)
-        rotada = _rotar_sen_recortar(imaxe, angulo)
+        rotada = _rotar_e_recortar_recheo(
+            imaxe,
+            angulo,
+            puntos_linas / escala,
+        )
         codificado = _codificar(rotada, tipo, contido)
         if codificado is None:
             return _sen_cambios(contido, "erro_de_codificacion", dimensions)
@@ -282,6 +306,147 @@ def _buscar_folla(
     return mellor
 
 
+def _buscar_folla_clara(
+    imaxe: np.ndarray,
+    gris: np.ndarray,
+    bordos: np.ndarray,
+) -> Optional[tuple[np.ndarray, float]]:
+    """Detecta unha folla clara sobre un fondo con cor ou textura.
+
+    Empréganse varios limiares próximos de saturación porque a iluminación e
+    o balance de brancos do móbil poden variar. Só se acepta un compoñente
+    central, convexo, que non toque o marco da fotografía e cuxos lados
+    coincidan maioritariamente con bordos reais da imaxe.
+    """
+
+    alto, ancho = gris.shape[:2]
+    area_imaxe = float(alto * ancho)
+    dimension = max(alto, ancho)
+    hsv = cv2.cvtColor(imaxe, cv2.COLOR_BGR2HSV)
+    saturacion = hsv[:, :, 1]
+    luminosidade = hsv[:, :, 2]
+
+    lado_peche = _impar(max(9, int(round(dimension * 0.013))))
+    lado_apertura = _impar(max(5, int(round(dimension * 0.005))))
+    kernel_peche = cv2.getStructuringElement(
+        cv2.MORPH_RECT,
+        (lado_peche, lado_peche),
+    )
+    kernel_apertura = cv2.getStructuringElement(
+        cv2.MORPH_RECT,
+        (lado_apertura, lado_apertura),
+    )
+
+    mellor: Optional[tuple[np.ndarray, float]] = None
+    mellor_confianza = 0.0
+
+    for limiar_saturacion in (8, 10, 12, 14):
+        mascara = np.where(
+            (saturacion < limiar_saturacion) & (luminosidade > 90),
+            255,
+            0,
+        ).astype(np.uint8)
+        mascara = cv2.morphologyEx(
+            mascara,
+            cv2.MORPH_CLOSE,
+            kernel_peche,
+            iterations=2,
+        )
+        mascara = cv2.morphologyEx(
+            mascara,
+            cv2.MORPH_OPEN,
+            kernel_apertura,
+            iterations=1,
+        )
+
+        contornos, _ = cv2.findContours(
+            mascara,
+            cv2.RETR_EXTERNAL,
+            cv2.CHAIN_APPROX_SIMPLE,
+        )
+        for contorno in sorted(contornos, key=cv2.contourArea, reverse=True)[:12]:
+            area = float(cv2.contourArea(contorno))
+            proporcion_area = area / area_imaxe
+            if not MIN_AREA_FOLLA_CLARA <= proporcion_area <= MAX_AREA_FOLLA_CLARA:
+                continue
+
+            envolvente = cv2.convexHull(contorno)
+            area_envolvente = float(cv2.contourArea(envolvente))
+            if area_envolvente <= 0 or area / area_envolvente < 0.92:
+                continue
+
+            perimetro = cv2.arcLength(envolvente, True)
+            aproximacion = None
+            for epsilon in (0.008, 0.01, 0.012, 0.015, 0.02, 0.025, 0.03):
+                posible = cv2.approxPolyDP(envolvente, epsilon * perimetro, True)
+                if len(posible) == 4 and cv2.isContourConvex(posible):
+                    aproximacion = posible
+                    break
+            if aproximacion is None:
+                continue
+
+            puntos = _ordenar_puntos(aproximacion.reshape(4, 2).astype(np.float32))
+            if len(np.unique(np.rint(puntos), axis=0)) != 4:
+                continue
+
+            marxe_imaxe = max(4, int(round(dimension * 0.004)))
+            if np.any(
+                (puntos[:, 0] <= marxe_imaxe)
+                | (puntos[:, 0] >= ancho - 1 - marxe_imaxe)
+                | (puntos[:, 1] <= marxe_imaxe)
+                | (puntos[:, 1] >= alto - 1 - marxe_imaxe)
+            ):
+                continue
+
+            angulos = _angulos_interiores(puntos)
+            if any(angulo < 55.0 or angulo > 125.0 for angulo in angulos):
+                continue
+
+            lados = _lonxitudes_lados(puntos)
+            if min(lados) < 0.22 * min(ancho, alto):
+                continue
+            if min(lados) / max(lados) < 0.42:
+                continue
+
+            centro = puntos.mean(axis=0)
+            distancia_centro = np.linalg.norm(
+                centro - np.array([ancho / 2.0, alto / 2.0])
+            )
+            if distancia_centro > 0.28 * np.hypot(ancho, alto):
+                continue
+
+            soportes = _soporte_de_bordo(bordos, puntos)
+            soporte = float(np.mean(soportes))
+            contraste = _contraste_do_contorno(gris, puntos)
+            if sum(valor >= 0.50 for valor in soportes) < 3:
+                continue
+            if soporte < 0.55 or contraste < 12.0:
+                continue
+
+            puntuacion_angulos = max(
+                0.0,
+                1.0 - np.mean(np.abs(np.array(angulos) - 90.0)) / 35.0,
+            )
+            confianza = (
+                0.20 * (area / area_envolvente)
+                + 0.30 * soporte
+                + 0.20 * min(1.0, contraste / 35.0)
+                + 0.15 * puntuacion_angulos
+                + 0.15 * min(1.0, proporcion_area / 0.50)
+            )
+            if confianza < 0.76:
+                continue
+            if mellor is None or confianza > mellor_confianza:
+                mellor = (puntos, float(confianza))
+                mellor_confianza = float(confianza)
+
+    return mellor
+
+
+def _impar(valor: int) -> int:
+    return valor if valor % 2 else valor + 1
+
+
 def _ordenar_puntos(puntos: np.ndarray) -> np.ndarray:
     suma = puntos.sum(axis=1)
     diferenza = np.diff(puntos, axis=1).reshape(-1)
@@ -371,6 +536,8 @@ def _corrixir_perspectiva(
     puntos: np.ndarray,
     confianza: float,
     tipo_contido: str,
+    motivo: str = "catro_bordos_detectados",
+    max_angulo: float = MAX_ANGULO_PERSPECTIVA,
 ) -> Optional[ResultadoPreprocesamento]:
     alto, ancho = imaxe.shape[:2]
     dimensions = (ancho, alto)
@@ -386,7 +553,7 @@ def _corrixir_perspectiva(
     deformacion = max(diferenza_anchos, diferenza_altos)
     if abs(inclinacion) < MIN_ANGULO_CORRECCION and deformacion < 0.035:
         return _sen_cambios(contido, "imaxe_xa_recta", dimensions)
-    if abs(inclinacion) > MAX_ANGULO_CORRECCION:
+    if abs(inclinacion) > max_angulo:
         return None
 
     centro = puntos.mean(axis=0)
@@ -436,7 +603,7 @@ def _corrixir_perspectiva(
         contido=datos_saida,
         aplicado=True,
         metodo="perspectiva",
-        motivo="catro_bordos_detectados",
+        motivo=motivo,
         angulo=round(inclinacion, 2),
         confianza=round(confianza, 3),
         dimensions_orixinais=dimensions,
@@ -445,7 +612,9 @@ def _corrixir_perspectiva(
     )
 
 
-def _estimar_inclinacion(bordos: np.ndarray) -> Optional[tuple[float, float]]:
+def _estimar_inclinacion(
+    bordos: np.ndarray,
+) -> Optional[tuple[float, float, np.ndarray]]:
     dimension = max(bordos.shape)
     linhas = cv2.HoughLinesP(
         bordos,
@@ -460,6 +629,7 @@ def _estimar_inclinacion(bordos: np.ndarray) -> Optional[tuple[float, float]]:
 
     angulos = []
     pesos = []
+    segmentos = []
     for x1, y1, x2, y2 in linhas[:, 0]:
         dx = float(x2 - x1)
         dy = float(y2 - y1)
@@ -467,9 +637,10 @@ def _estimar_inclinacion(bordos: np.ndarray) -> Optional[tuple[float, float]]:
         if lonxitude < dimension * 0.16:
             continue
         angulo = _normalizar_angulo(np.degrees(np.arctan2(dy, dx)))
-        if abs(angulo) <= MAX_ANGULO_CORRECCION:
+        if abs(angulo) <= MAX_ANGULO_INCLINACION:
             angulos.append(angulo)
             pesos.append(lonxitude)
+            segmentos.append((float(x1), float(y1), float(x2), float(y2)))
 
     if len(angulos) < 5:
         return None
@@ -488,7 +659,9 @@ def _estimar_inclinacion(bordos: np.ndarray) -> Optional[tuple[float, float]]:
         return None
 
     confianza = min(0.97, 0.45 + 0.45 * consenso + 0.10 * (1.0 - desviacion / 1.5))
-    return float(mediana), float(confianza)
+    segmentos_array = np.asarray(segmentos, dtype=float)[mascara]
+    puntos_linas = segmentos_array.reshape(-1, 2)
+    return float(mediana), float(confianza), puntos_linas
 
 
 def _normalizar_angulo(angulo: float) -> float:
@@ -508,14 +681,26 @@ def _mediana_ponderada(valores: np.ndarray, pesos: np.ndarray) -> float:
     return float(valores_ordenados[min(indice, len(valores_ordenados) - 1)])
 
 
-def _rotar_sen_recortar(imaxe: np.ndarray, angulo: float) -> np.ndarray:
+def _rotar_e_recortar_recheo(
+    imaxe: np.ndarray,
+    angulo: float,
+    puntos_linas: np.ndarray,
+) -> np.ndarray:
+    """Rota o lenzo e reduce de forma conservadora o recheo branco creado.
+
+    O recorte só se tenta en xiros amplos. Retense como mínimo o 80 % dos
+    píxeles procedentes da fotografía e garántese que as liñas que xustifican
+    a corrección queden dentro cunha marxe ampla. Non se pretende inferir o
+    bordo da folla: só reducir os triángulos artificiais da rotación.
+    """
+
     alto, ancho = imaxe.shape[:2]
     centro = (ancho / 2.0, alto / 2.0)
     matriz = cv2.getRotationMatrix2D(centro, angulo, 1.0)
     novo_ancho, novo_alto = _dimensions_rotacion(ancho, alto, angulo)
     matriz[0, 2] += novo_ancho / 2.0 - centro[0]
     matriz[1, 2] += novo_alto / 2.0 - centro[1]
-    return cv2.warpAffine(
+    rotada = cv2.warpAffine(
         imaxe,
         matriz,
         (novo_ancho, novo_alto),
@@ -523,6 +708,61 @@ def _rotar_sen_recortar(imaxe: np.ndarray, angulo: float) -> np.ndarray:
         borderMode=cv2.BORDER_CONSTANT,
         borderValue=(255, 255, 255),
     )
+    if abs(angulo) < 10.0:
+        return rotada
+
+    mascara_orixe = np.full((alto, ancho), 255, dtype=np.uint8)
+    mascara_rotada = cv2.warpAffine(
+        mascara_orixe,
+        matriz,
+        (novo_ancho, novo_alto),
+        flags=cv2.INTER_NEAREST,
+        borderMode=cv2.BORDER_CONSTANT,
+        borderValue=0,
+    )
+    valida = mascara_rotada > 0
+    total_validos = int(np.count_nonzero(valida))
+    if total_validos == 0:
+        return rotada
+
+    limiar_inicial = min(0.35, max(0.15, abs(angulo) / 75.0))
+    recorte = None
+    for limiar in np.arange(limiar_inicial, 0.09, -0.05):
+        filas = np.flatnonzero(np.mean(valida, axis=1) >= limiar)
+        columnas = np.flatnonzero(np.mean(valida, axis=0) >= limiar)
+        if len(filas) == 0 or len(columnas) == 0:
+            continue
+        x1, x2 = int(columnas[0]), int(columnas[-1] + 1)
+        y1, y2 = int(filas[0]), int(filas[-1] + 1)
+        retidos = int(np.count_nonzero(valida[y1:y2, x1:x2])) / total_validos
+        if retidos >= 0.80:
+            recorte = [x1, y1, x2, y2]
+            break
+    if recorte is None:
+        return rotada
+
+    x1, y1, x2, y2 = recorte
+    transformados = cv2.transform(
+        puntos_linas.astype(np.float32).reshape(-1, 1, 2),
+        matriz,
+    ).reshape(-1, 2)
+    marxe_contido = max(40, int(round(min(ancho, alto) * 0.12)))
+    x1 = min(x1, max(0, int(np.floor(transformados[:, 0].min())) - marxe_contido))
+    y1 = min(y1, max(0, int(np.floor(transformados[:, 1].min())) - marxe_contido))
+    x2 = max(
+        x2,
+        min(novo_ancho, int(np.ceil(transformados[:, 0].max())) + marxe_contido),
+    )
+    y2 = max(
+        y2,
+        min(novo_alto, int(np.ceil(transformados[:, 1].max())) + marxe_contido),
+    )
+
+    if x2 - x1 < 0.72 * ancho or y2 - y1 < 0.72 * alto:
+        return rotada
+    if (x2 - x1) * (y2 - y1) > 0.96 * novo_ancho * novo_alto:
+        return rotada
+    return rotada[y1:y2, x1:x2]
 
 
 def _dimensions_rotacion(ancho: int, alto: int, angulo: float) -> tuple[int, int]:
@@ -540,23 +780,31 @@ def _codificar(
     contido_orixinal: bytes,
 ) -> Optional[tuple[bytes, str]]:
     e_png = tipo_contido == "image/png" or contido_orixinal.startswith(b"\x89PNG\r\n\x1a\n")
+    limite = _limite_bytes_saida()
     if e_png:
-        correcto, datos = cv2.imencode(".png", imaxe, [cv2.IMWRITE_PNG_COMPRESSION, 3])
-        formato = "png"
-    else:
-        parametros = [cv2.IMWRITE_JPEG_QUALITY, 97]
-        if hasattr(cv2, "IMWRITE_JPEG_SAMPLING_FACTOR_444"):
-            parametros.extend(
-                [
-                    cv2.IMWRITE_JPEG_SAMPLING_FACTOR,
-                    cv2.IMWRITE_JPEG_SAMPLING_FACTOR_444,
-                ]
+        for compresion in (3, 6, 9):
+            correcto, datos = cv2.imencode(
+                ".png",
+                imaxe,
+                [cv2.IMWRITE_PNG_COMPRESSION, compresion],
             )
-        correcto, datos = cv2.imencode(".jpg", imaxe, parametros)
-        formato = "jpg"
-    if not correcto:
+            if correcto and len(datos) <= limite:
+                return datos.tobytes(), "png"
         return None
-    resultado = datos.tobytes()
-    if len(resultado) > _limite_bytes_saida():
+    else:
+        # Selecciónase sempre a maior calidade que caiba no límite. A maioría
+        # dos recortes entran a 97; a redución gradual só se emprega cando a
+        # rotación do lenzo completo aumenta o tamaño do JPEG.
+        for calidade in (97, 96, 95, 94, 93, 92):
+            parametros = [cv2.IMWRITE_JPEG_QUALITY, calidade]
+            if hasattr(cv2, "IMWRITE_JPEG_SAMPLING_FACTOR_444"):
+                parametros.extend(
+                    [
+                        cv2.IMWRITE_JPEG_SAMPLING_FACTOR,
+                        cv2.IMWRITE_JPEG_SAMPLING_FACTOR_444,
+                    ]
+                )
+            correcto, datos = cv2.imencode(".jpg", imaxe, parametros)
+            if correcto and len(datos) <= limite:
+                return datos.tobytes(), "jpg"
         return None
-    return resultado, formato

--- a/server/app/internal/preprocesamento.py
+++ b/server/app/internal/preprocesamento.py
@@ -1,0 +1,562 @@
+"""Preprocesamento conservador das imaxes antes do recoñecemento OCR.
+
+As transformacións só se aplican cando hai evidencias suficientes de que a
+folla está inclinada ou deformada pola perspectiva. Ante calquera dúbida ou
+erro devólvense exactamente os bytes recibidos.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+import cv2
+import numpy as np
+
+
+MAX_DIMENSION_DETECCION = 1600
+MIN_DIMENSION_IMAXE = 160
+MIN_AREA_FOLLA = 0.38
+MAX_AREA_FOLLA = 0.96
+MIN_ANGULO_CORRECCION = 0.7
+MAX_ANGULO_CORRECCION = 15.0
+MAX_PIXELES_PREPROCESAMENTO = 30_000_000
+MAX_LADO_AZURE = 10_000
+MAX_BYTES_PREDETERMINADOS = 3_900_000
+
+
+@dataclass(frozen=True)
+class ResultadoPreprocesamento:
+    """Resultado e datos de diagnóstico dunha tentativa de corrección."""
+
+    contido: bytes
+    aplicado: bool
+    metodo: str
+    motivo: str
+    angulo: float = 0.0
+    confianza: float = 0.0
+    dimensions_orixinais: Optional[tuple[int, int]] = None
+    dimensions_saida: Optional[tuple[int, int]] = None
+    formato_saida: Optional[str] = None
+
+
+def preprocesar_documento(
+    contido: bytes,
+    tipo_contido: Optional[str] = None,
+    activado: Optional[bool] = None,
+) -> ResultadoPreprocesamento:
+    """Endereita unha imaxe cando a corrección se pode facer con seguridade.
+
+    Os PDF, os formatos que OpenCV non pode decodificar e as deteccións de
+    baixa confianza pasan sen modificacións. ``activado`` permite forzar o
+    comportamento nas probas; se non se indica emprégase a variable de
+    contorno ``PREPROCESS_IMAGES`` (activada por defecto).
+    """
+
+    if not contido:
+        return _sen_cambios(contido, "ficheiro_baleiro")
+
+    if not _preprocesamento_activado(activado):
+        return _sen_cambios(contido, "desactivado")
+
+    tipo = (tipo_contido or "").lower().split(";", 1)[0].strip()
+    if tipo == "application/pdf" or contido.lstrip().startswith(b"%PDF-"):
+        return _sen_cambios(contido, "pdf")
+
+    if tipo in {"image/heic", "image/heif"} or _parece_heif(contido):
+        return _sen_cambios(contido, "heif_non_decodificable")
+
+    if tipo and not (tipo.startswith("image/") or tipo == "application/octet-stream"):
+        return _sen_cambios(contido, "tipo_non_soportado")
+
+    if len(contido) > _limite_bytes_saida():
+        return _sen_cambios(contido, "ficheiro_supera_limite_preprocesamento")
+
+    try:
+        datos = np.frombuffer(contido, dtype=np.uint8)
+        imaxe = cv2.imdecode(datos, cv2.IMREAD_COLOR)
+        if imaxe is None:
+            return _sen_cambios(contido, "imaxe_non_decodificable")
+
+        alto, ancho = imaxe.shape[:2]
+        dimensions = (ancho, alto)
+        if min(ancho, alto) < MIN_DIMENSION_IMAXE:
+            return _sen_cambios(contido, "imaxe_demasiado_pequena", dimensions)
+        if max(ancho, alto) > MAX_LADO_AZURE or ancho * alto > MAX_PIXELES_PREPROCESAMENTO:
+            return _sen_cambios(contido, "dimensions_fora_do_limite", dimensions)
+
+        imaxe_deteccion, escala = _preparar_deteccion(imaxe)
+        gris, bordos = _detectar_bordos(imaxe_deteccion)
+
+        candidato = _buscar_folla(gris, bordos)
+        if candidato is not None:
+            cuadrilatero, confianza = candidato
+            resultado = _corrixir_perspectiva(
+                contido,
+                imaxe,
+                cuadrilatero / escala,
+                confianza,
+                tipo,
+            )
+            if resultado is not None:
+                return resultado
+
+        correccion = _estimar_inclinacion(bordos)
+        if correccion is None:
+            return _sen_cambios(contido, "deteccion_sen_confianza", dimensions)
+
+        angulo, confianza = correccion
+        if abs(angulo) < MIN_ANGULO_CORRECCION:
+            return _sen_cambios(contido, "imaxe_xa_recta", dimensions)
+
+        ancho_rotada, alto_rotada = _dimensions_rotacion(ancho, alto, angulo)
+        if (
+            max(ancho_rotada, alto_rotada) > MAX_LADO_AZURE
+            or ancho_rotada * alto_rotada > MAX_PIXELES_PREPROCESAMENTO
+        ):
+            return _sen_cambios(contido, "saida_supera_limite_de_dimensions", dimensions)
+        rotada = _rotar_sen_recortar(imaxe, angulo)
+        codificado = _codificar(rotada, tipo, contido)
+        if codificado is None:
+            return _sen_cambios(contido, "erro_de_codificacion", dimensions)
+
+        datos_saida, formato = codificado
+        alto_saida, ancho_saida = rotada.shape[:2]
+        return ResultadoPreprocesamento(
+            contido=datos_saida,
+            aplicado=True,
+            metodo="inclinacion",
+            motivo="linas_con_orientacion_consistente",
+            angulo=round(float(angulo), 2),
+            confianza=round(float(confianza), 3),
+            dimensions_orixinais=dimensions,
+            dimensions_saida=(ancho_saida, alto_saida),
+            formato_saida=formato,
+        )
+    except (cv2.error, MemoryError, ValueError, TypeError) as erro:
+        logging.warning("Non se puido preprocesar a imaxe: %s", type(erro).__name__)
+        return _sen_cambios(contido, "erro_de_preprocesamento")
+    except Exception as erro:  # O preprocesamento nunca debe bloquear o OCR.
+        logging.warning("Erro inesperado no preprocesamento: %s", type(erro).__name__)
+        return _sen_cambios(contido, "erro_inesperado")
+
+
+def _preprocesamento_activado(valor: Optional[bool]) -> bool:
+    if valor is not None:
+        return valor
+    return os.getenv("PREPROCESS_IMAGES", "true").strip().lower() not in {
+        "0",
+        "false",
+        "non",
+        "no",
+        "off",
+    }
+
+
+def _limite_bytes_saida() -> int:
+    try:
+        return max(10_000, int(os.getenv("PREPROCESS_MAX_BYTES", MAX_BYTES_PREDETERMINADOS)))
+    except (TypeError, ValueError):
+        return MAX_BYTES_PREDETERMINADOS
+
+
+def _parece_heif(contido: bytes) -> bool:
+    if len(contido) < 12 or contido[4:8] != b"ftyp":
+        return False
+    marca = contido[8:12].lower()
+    return marca in {b"heic", b"heix", b"hevc", b"hevx", b"mif1", b"msf1"}
+
+
+def _sen_cambios(
+    contido: bytes,
+    motivo: str,
+    dimensions: Optional[tuple[int, int]] = None,
+) -> ResultadoPreprocesamento:
+    return ResultadoPreprocesamento(
+        contido=contido,
+        aplicado=False,
+        metodo="sen_cambios",
+        motivo=motivo,
+        dimensions_orixinais=dimensions,
+        dimensions_saida=dimensions,
+    )
+
+
+def _preparar_deteccion(imaxe: np.ndarray) -> tuple[np.ndarray, float]:
+    alto, ancho = imaxe.shape[:2]
+    escala = min(1.0, MAX_DIMENSION_DETECCION / float(max(ancho, alto)))
+    if escala == 1.0:
+        return imaxe, escala
+    reducida = cv2.resize(imaxe, None, fx=escala, fy=escala, interpolation=cv2.INTER_AREA)
+    return reducida, escala
+
+
+def _detectar_bordos(imaxe: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    gris = cv2.cvtColor(imaxe, cv2.COLOR_BGR2GRAY)
+    suavizada = cv2.GaussianBlur(gris, (5, 5), 0)
+    mediana = float(np.median(suavizada))
+    limiar_baixo = int(max(30, 0.66 * mediana))
+    limiar_alto = int(min(220, max(limiar_baixo + 40, 1.33 * mediana)))
+    bordos = cv2.Canny(suavizada, limiar_baixo, limiar_alto)
+    kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (3, 3))
+    bordos = cv2.morphologyEx(bordos, cv2.MORPH_CLOSE, kernel, iterations=1)
+    return gris, bordos
+
+
+def _buscar_folla(
+    gris: np.ndarray,
+    bordos: np.ndarray,
+) -> Optional[tuple[np.ndarray, float]]:
+    alto, ancho = gris.shape[:2]
+    area_imaxe = float(alto * ancho)
+    contornos, _ = cv2.findContours(bordos, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
+    mellor: Optional[tuple[np.ndarray, float]] = None
+    mellor_area = 0.0
+
+    for contorno in sorted(contornos, key=cv2.contourArea, reverse=True)[:30]:
+        perimetro = cv2.arcLength(contorno, True)
+        if perimetro <= 0:
+            continue
+
+        aproximacion = None
+        for epsilon in (0.015, 0.02, 0.025, 0.03):
+            posible = cv2.approxPolyDP(contorno, epsilon * perimetro, True)
+            if len(posible) == 4:
+                aproximacion = posible
+                break
+        if aproximacion is None or not cv2.isContourConvex(aproximacion):
+            continue
+
+        puntos = _ordenar_puntos(aproximacion.reshape(4, 2).astype(np.float32))
+        if len(np.unique(np.rint(puntos), axis=0)) != 4:
+            continue
+
+        area = abs(cv2.contourArea(puntos))
+        proporcion_area = area / area_imaxe
+        if not MIN_AREA_FOLLA <= proporcion_area <= MAX_AREA_FOLLA:
+            continue
+
+        angulos = _angulos_interiores(puntos)
+        if any(angulo < 55.0 or angulo > 125.0 for angulo in angulos):
+            continue
+
+        lados = _lonxitudes_lados(puntos)
+        if min(lados) < 0.28 * min(ancho, alto):
+            continue
+        if min(lados) / max(lados) < 0.42:
+            continue
+
+        centro = puntos.mean(axis=0)
+        distancia_centro = np.linalg.norm(centro - np.array([ancho / 2, alto / 2]))
+        if distancia_centro > 0.24 * np.hypot(ancho, alto):
+            continue
+
+        soportes = _soporte_de_bordo(bordos, puntos)
+        soporte = float(np.mean(soportes))
+        contraste = _contraste_do_contorno(gris, puntos)
+        if min(soportes) < 0.35 or sum(valor >= 0.55 for valor in soportes) < 3:
+            continue
+        if soporte < 0.55 or contraste < 8.0:
+            continue
+
+        puntuacion_area = min(1.0, proporcion_area / 0.65)
+        puntuacion_angulos = max(0.0, 1.0 - np.mean(np.abs(np.array(angulos) - 90.0)) / 35.0)
+        puntuacion_contraste = min(1.0, contraste / 35.0)
+        confianza = (
+            0.25 * puntuacion_area
+            + 0.25 * puntuacion_angulos
+            + 0.30 * soporte
+            + 0.20 * puntuacion_contraste
+        )
+        if confianza < 0.72:
+            continue
+
+        # Entre candidatos fiables prefírese a silueta de maior área. Isto
+        # evita escoller un marco impreso situado uns píxeles dentro do papel.
+        if mellor is None or proporcion_area > mellor_area:
+            mellor = (puntos, float(confianza))
+            mellor_area = proporcion_area
+
+    return mellor
+
+
+def _ordenar_puntos(puntos: np.ndarray) -> np.ndarray:
+    suma = puntos.sum(axis=1)
+    diferenza = np.diff(puntos, axis=1).reshape(-1)
+    return np.array(
+        [
+            puntos[np.argmin(suma)],
+            puntos[np.argmin(diferenza)],
+            puntos[np.argmax(suma)],
+            puntos[np.argmax(diferenza)],
+        ],
+        dtype=np.float32,
+    )
+
+
+def _angulos_interiores(puntos: np.ndarray) -> list[float]:
+    angulos = []
+    for indice, punto in enumerate(puntos):
+        anterior = puntos[(indice - 1) % 4] - punto
+        seguinte = puntos[(indice + 1) % 4] - punto
+        denominador = np.linalg.norm(anterior) * np.linalg.norm(seguinte)
+        if denominador == 0:
+            return [0.0] * 4
+        coseno = np.clip(np.dot(anterior, seguinte) / denominador, -1.0, 1.0)
+        angulos.append(float(np.degrees(np.arccos(coseno))))
+    return angulos
+
+
+def _lonxitudes_lados(puntos: np.ndarray) -> list[float]:
+    return [
+        float(np.linalg.norm(puntos[(indice + 1) % 4] - puntos[indice]))
+        for indice in range(4)
+    ]
+
+
+def _soporte_de_bordo(bordos: np.ndarray, puntos: np.ndarray) -> list[float]:
+    grosor = max(3, int(round(max(bordos.shape) * 0.004)))
+    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (2 * grosor + 1, 2 * grosor + 1))
+    dilatados = cv2.dilate(bordos, kernel)
+    soportes = []
+    for indice in range(4):
+        inicio = puntos[indice]
+        fin = puntos[(indice + 1) % 4]
+        mostras = max(40, int(np.linalg.norm(fin - inicio)))
+        xs = np.linspace(inicio[0], fin[0], mostras).round().astype(int)
+        ys = np.linspace(inicio[1], fin[1], mostras).round().astype(int)
+        xs = np.clip(xs, 0, bordos.shape[1] - 1)
+        ys = np.clip(ys, 0, bordos.shape[0] - 1)
+        soportes.append(float(np.mean(dilatados[ys, xs] > 0)))
+    return soportes
+
+
+def _contraste_do_contorno(gris: np.ndarray, puntos: np.ndarray) -> float:
+    # Compáranse mostras afastadas da propia liña do contorno. Deste xeito,
+    # unha caixa ou unha táboa impresa dentro da folla non se confunde coa
+    # silueta exterior do papel.
+    # A banda queda suficientemente afastada para non medir un marco impreso
+    # preto que estea situado xusto no bordo da folla.
+    desprazamento = max(8.0, min(gris.shape) * 0.03)
+    contrastes = []
+    for indice in range(4):
+        inicio = puntos[indice]
+        fin = puntos[(indice + 1) % 4]
+        vector = fin - inicio
+        lonxitude = float(np.linalg.norm(vector))
+        if lonxitude == 0:
+            return 0.0
+        normal_interior = np.array([-vector[1], vector[0]], dtype=np.float32) / lonxitude
+        proporcions = np.linspace(0.12, 0.88, max(40, int(lonxitude / 4)))
+        base = inicio[None, :] + proporcions[:, None] * vector[None, :]
+        interior = base + normal_interior[None, :] * desprazamento
+        exterior = base - normal_interior[None, :] * desprazamento
+
+        xi = np.clip(np.rint(interior[:, 0]).astype(int), 0, gris.shape[1] - 1)
+        yi = np.clip(np.rint(interior[:, 1]).astype(int), 0, gris.shape[0] - 1)
+        xe = np.clip(np.rint(exterior[:, 0]).astype(int), 0, gris.shape[1] - 1)
+        ye = np.clip(np.rint(exterior[:, 1]).astype(int), 0, gris.shape[0] - 1)
+        contrastes.append(float(np.median(gris[yi, xi])) - float(np.median(gris[ye, xe])))
+
+    # O percentil 25 obriga a que, como mínimo, tres lados presenten un
+    # contraste compatible cun límite real da folla.
+    return float(np.percentile(contrastes, 25))
+
+
+def _corrixir_perspectiva(
+    contido: bytes,
+    imaxe: np.ndarray,
+    puntos: np.ndarray,
+    confianza: float,
+    tipo_contido: str,
+) -> Optional[ResultadoPreprocesamento]:
+    alto, ancho = imaxe.shape[:2]
+    dimensions = (ancho, alto)
+    lados = _lonxitudes_lados(puntos)
+    angulos_lados = []
+    for indice in range(4):
+        vector = puntos[(indice + 1) % 4] - puntos[indice]
+        angulos_lados.append(_normalizar_angulo(np.degrees(np.arctan2(vector[1], vector[0]))))
+
+    inclinacion = float(np.median(angulos_lados))
+    diferenza_anchos = abs(lados[0] - lados[2]) / max(lados[0], lados[2])
+    diferenza_altos = abs(lados[1] - lados[3]) / max(lados[1], lados[3])
+    deformacion = max(diferenza_anchos, diferenza_altos)
+    if abs(inclinacion) < MIN_ANGULO_CORRECCION and deformacion < 0.035:
+        return _sen_cambios(contido, "imaxe_xa_recta", dimensions)
+    if abs(inclinacion) > MAX_ANGULO_CORRECCION:
+        return None
+
+    centro = puntos.mean(axis=0)
+    # Engádese unha marxe pequena para non cortar texto situado xunto a un
+    # bordo impreso que se detectase lixeiramente dentro da silueta do papel.
+    marxe = centro + (puntos - centro) * 1.04
+    marxe[:, 0] = np.clip(marxe[:, 0], 0, ancho - 1)
+    marxe[:, 1] = np.clip(marxe[:, 1], 0, alto - 1)
+    superior_esq, superior_der, inferior_der, inferior_esq = marxe
+
+    ancho_superior = np.linalg.norm(superior_der - superior_esq)
+    ancho_inferior = np.linalg.norm(inferior_der - inferior_esq)
+    alto_esquerdo = np.linalg.norm(inferior_esq - superior_esq)
+    alto_dereito = np.linalg.norm(inferior_der - superior_der)
+    ancho_saida = int(round(max(ancho_superior, ancho_inferior)))
+    alto_saida = int(round(max(alto_esquerdo, alto_dereito)))
+    if min(ancho_saida, alto_saida) < MIN_DIMENSION_IMAXE:
+        return None
+    if max(ancho_saida, alto_saida) > MAX_LADO_AZURE:
+        return None
+    if ancho_saida * alto_saida > 1.35 * ancho * alto:
+        return None
+
+    destino = np.array(
+        [
+            [0, 0],
+            [ancho_saida - 1, 0],
+            [ancho_saida - 1, alto_saida - 1],
+            [0, alto_saida - 1],
+        ],
+        dtype=np.float32,
+    )
+    matriz = cv2.getPerspectiveTransform(marxe.astype(np.float32), destino)
+    corrixida = cv2.warpPerspective(
+        imaxe,
+        matriz,
+        (ancho_saida, alto_saida),
+        flags=cv2.INTER_CUBIC,
+        borderMode=cv2.BORDER_CONSTANT,
+        borderValue=(255, 255, 255),
+    )
+    codificado = _codificar(corrixida, tipo_contido, contido)
+    if codificado is None:
+        return _sen_cambios(contido, "saida_non_valida", dimensions)
+    datos_saida, formato = codificado
+    return ResultadoPreprocesamento(
+        contido=datos_saida,
+        aplicado=True,
+        metodo="perspectiva",
+        motivo="catro_bordos_detectados",
+        angulo=round(inclinacion, 2),
+        confianza=round(confianza, 3),
+        dimensions_orixinais=dimensions,
+        dimensions_saida=(ancho_saida, alto_saida),
+        formato_saida=formato,
+    )
+
+
+def _estimar_inclinacion(bordos: np.ndarray) -> Optional[tuple[float, float]]:
+    dimension = max(bordos.shape)
+    linhas = cv2.HoughLinesP(
+        bordos,
+        1,
+        np.pi / 1800,
+        threshold=max(45, int(dimension * 0.035)),
+        minLineLength=max(50, int(dimension * 0.16)),
+        maxLineGap=max(10, int(dimension * 0.025)),
+    )
+    if linhas is None:
+        return None
+
+    angulos = []
+    pesos = []
+    for x1, y1, x2, y2 in linhas[:, 0]:
+        dx = float(x2 - x1)
+        dy = float(y2 - y1)
+        lonxitude = float(np.hypot(dx, dy))
+        if lonxitude < dimension * 0.16:
+            continue
+        angulo = _normalizar_angulo(np.degrees(np.arctan2(dy, dx)))
+        if abs(angulo) <= MAX_ANGULO_CORRECCION:
+            angulos.append(angulo)
+            pesos.append(lonxitude)
+
+    if len(angulos) < 5:
+        return None
+
+    valores = np.asarray(angulos, dtype=float)
+    pesos_array = np.asarray(pesos, dtype=float)
+    mediana = _mediana_ponderada(valores, pesos_array)
+    distancias = np.abs(valores - mediana)
+    mascara = distancias <= 2.0
+    if int(np.count_nonzero(mascara)) < 4:
+        return None
+
+    consenso = float(pesos_array[mascara].sum() / pesos_array.sum())
+    desviacion = _mediana_ponderada(distancias[mascara], pesos_array[mascara])
+    if consenso < 0.65 or desviacion > 1.5:
+        return None
+
+    confianza = min(0.97, 0.45 + 0.45 * consenso + 0.10 * (1.0 - desviacion / 1.5))
+    return float(mediana), float(confianza)
+
+
+def _normalizar_angulo(angulo: float) -> float:
+    while angulo <= -45.0:
+        angulo += 90.0
+    while angulo > 45.0:
+        angulo -= 90.0
+    return float(angulo)
+
+
+def _mediana_ponderada(valores: np.ndarray, pesos: np.ndarray) -> float:
+    orde = np.argsort(valores)
+    valores_ordenados = valores[orde]
+    pesos_ordenados = pesos[orde]
+    acumulados = np.cumsum(pesos_ordenados)
+    indice = int(np.searchsorted(acumulados, pesos_ordenados.sum() / 2.0, side="left"))
+    return float(valores_ordenados[min(indice, len(valores_ordenados) - 1)])
+
+
+def _rotar_sen_recortar(imaxe: np.ndarray, angulo: float) -> np.ndarray:
+    alto, ancho = imaxe.shape[:2]
+    centro = (ancho / 2.0, alto / 2.0)
+    matriz = cv2.getRotationMatrix2D(centro, angulo, 1.0)
+    novo_ancho, novo_alto = _dimensions_rotacion(ancho, alto, angulo)
+    matriz[0, 2] += novo_ancho / 2.0 - centro[0]
+    matriz[1, 2] += novo_alto / 2.0 - centro[1]
+    return cv2.warpAffine(
+        imaxe,
+        matriz,
+        (novo_ancho, novo_alto),
+        flags=cv2.INTER_CUBIC,
+        borderMode=cv2.BORDER_CONSTANT,
+        borderValue=(255, 255, 255),
+    )
+
+
+def _dimensions_rotacion(ancho: int, alto: int, angulo: float) -> tuple[int, int]:
+    radiáns = np.radians(angulo)
+    coseno = abs(float(np.cos(radiáns)))
+    seno = abs(float(np.sin(radiáns)))
+    novo_ancho = int(np.ceil(alto * seno + ancho * coseno))
+    novo_alto = int(np.ceil(alto * coseno + ancho * seno))
+    return novo_ancho, novo_alto
+
+
+def _codificar(
+    imaxe: np.ndarray,
+    tipo_contido: str,
+    contido_orixinal: bytes,
+) -> Optional[tuple[bytes, str]]:
+    e_png = tipo_contido == "image/png" or contido_orixinal.startswith(b"\x89PNG\r\n\x1a\n")
+    if e_png:
+        correcto, datos = cv2.imencode(".png", imaxe, [cv2.IMWRITE_PNG_COMPRESSION, 3])
+        formato = "png"
+    else:
+        parametros = [cv2.IMWRITE_JPEG_QUALITY, 97]
+        if hasattr(cv2, "IMWRITE_JPEG_SAMPLING_FACTOR_444"):
+            parametros.extend(
+                [
+                    cv2.IMWRITE_JPEG_SAMPLING_FACTOR,
+                    cv2.IMWRITE_JPEG_SAMPLING_FACTOR_444,
+                ]
+            )
+        correcto, datos = cv2.imencode(".jpg", imaxe, parametros)
+        formato = "jpg"
+    if not correcto:
+        return None
+    resultado = datos.tobytes()
+    if len(resultado) > _limite_bytes_saida():
+        return None
+    return resultado, formato

--- a/server/app/routers/extraccion.py
+++ b/server/app/routers/extraccion.py
@@ -9,6 +9,7 @@ from app.schemas.models import AnalisisResponse, ErrorResponse, CabeceiraRespons
 from app.internal.logic import extraer_data, calcular_confianza_media, parsear_data, parse_dose_cell, \
     extraer_dose_semanal
 from app.internal.constants import MODEL_ID, DOSE_COLS, INR_MIN_LOGICO, INR_MAX_LOGICO
+from app.internal.preprocesamento import preprocesar_documento
 
 
 router = APIRouter(
@@ -70,7 +71,7 @@ async def iniciar_extraccion(file: UploadFile = File(... ,description="Imaxe ou 
     e devolve un JSON coa información relevante limpa para a nosa app.
     """
 
-    if file.content_type not in ["image/jpeg", "image/png", "image/heic", "application/pdf", "application/octet-stream"]:
+    if file.content_type not in ["image/jpeg", "image/png", "image/heic", "image/heif", "application/pdf", "application/octet-stream"]:
         raise HTTPException(
             status_code=400,
             detail=f"Tipo de ficheiro non soportado: {file.content_type}"
@@ -79,7 +80,17 @@ async def iniciar_extraccion(file: UploadFile = File(... ,description="Imaxe ou 
     try:
         #Leemos o ficheiro que envoiu o usurio
         image_content = await file.read()
-        logging.info(f"iniciando o análise da imaxe")
+        resultado_preprocesamento = preprocesar_documento(image_content, file.content_type)
+        image_content = resultado_preprocesamento.contido
+        logging.info(
+            "Preprocesamento do documento: metodo=%s, aplicado=%s, angulo=%s, confianza=%s, motivo=%s",
+            resultado_preprocesamento.metodo,
+            resultado_preprocesamento.aplicado,
+            resultado_preprocesamento.angulo,
+            resultado_preprocesamento.confianza,
+            resultado_preprocesamento.motivo,
+        )
+        logging.info("Iniciando a análise do documento")
 
         #Chamamos ao modelo de Azure
         ocr_operation = client.begin_analyze_document(

--- a/server/scripts/probar_preprocesamento.py
+++ b/server/scripts/probar_preprocesamento.py
@@ -1,0 +1,79 @@
+"""Garda localmente o resultado do preprocesamento dunha fotografía.
+
+Exemplo desde a raíz do repositorio:
+
+    .venv\Scripts\python.exe server\scripts\probar_preprocesamento.py foto.jpg
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+import sys
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+
+
+RAIZ_SERVER = Path(__file__).resolve().parents[1]
+if str(RAIZ_SERVER) not in sys.path:
+    sys.path.insert(0, str(RAIZ_SERVER))
+
+from app.internal.preprocesamento import preprocesar_documento  # noqa: E402
+
+
+def _crear_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Endereita unha imaxe e garda o resultado para revisalo antes de integrar o cambio."
+    )
+    parser.add_argument("imaxe", type=Path, help="Ruta da imaxe que se quere probar")
+    parser.add_argument(
+        "--saida",
+        type=Path,
+        default=RAIZ_SERVER / "tmp" / "preprocesamento",
+        help="Directorio local de saída (por defecto: server/tmp/preprocesamento)",
+    )
+    return parser
+
+
+def main() -> int:
+    argumentos = _crear_parser().parse_args()
+    ruta_imaxe = argumentos.imaxe.resolve()
+    if not ruta_imaxe.is_file():
+        print(f"Non se atopou a imaxe: {ruta_imaxe}", file=sys.stderr)
+        return 2
+
+    contido = ruta_imaxe.read_bytes()
+    tipo_contido = mimetypes.guess_type(ruta_imaxe.name)[0] or "application/octet-stream"
+    resultado = preprocesar_documento(contido, tipo_contido, activado=True)
+
+    directorio_saida = argumentos.saida.resolve()
+    directorio_saida.mkdir(parents=True, exist_ok=True)
+    extension = f".{resultado.formato_saida}" if resultado.formato_saida else ruta_imaxe.suffix
+    identificador = datetime.now().strftime("%Y%m%d-%H%M%S")
+    ruta_resultado = directorio_saida / f"resultado-{identificador}{extension}"
+    ruta_metadatos = directorio_saida / f"resultado-{identificador}.json"
+    ruta_resultado.write_bytes(resultado.contido)
+
+    metadatos = asdict(resultado)
+    metadatos.pop("contido")
+    ruta_metadatos.write_text(
+        json.dumps(metadatos, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    estado = "transformada" if resultado.aplicado else "conservada sen cambios"
+    print(f"Imaxe {estado}.")
+    print(f"Método: {resultado.metodo}")
+    print(f"Motivo: {resultado.motivo}")
+    print(f"Ángulo estimado: {resultado.angulo}°")
+    print(f"Confianza: {resultado.confianza}")
+    print(f"Resultado: {ruta_resultado}")
+    print(f"Diagnóstico: {ruta_metadatos}")
+    print("Aviso: estes ficheiros son só para a proba local; elimínaos cando remates.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/test/test_preprocesamento.py
+++ b/server/test/test_preprocesamento.py
@@ -1,0 +1,241 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+import cv2
+import numpy as np
+from fastapi.testclient import TestClient
+
+from app.internal.preprocesamento import ResultadoPreprocesamento, preprocesar_documento
+from server.app.main import app
+
+
+def _codificar(imaxe: np.ndarray, extension: str = ".png") -> bytes:
+    correcto, datos = cv2.imencode(extension, imaxe)
+    if not correcto:
+        raise RuntimeError("Non se puido preparar a imaxe de proba")
+    return datos.tobytes()
+
+
+def _crear_folla(ancho: int = 560, alto: int = 760, con_bordo: bool = True) -> np.ndarray:
+    imaxe = np.full((alto, ancho, 3), 255, dtype=np.uint8)
+    if con_bordo:
+        cv2.rectangle(imaxe, (12, 12), (ancho - 13, alto - 13), (20, 20, 20), 5)
+    for y in range(100, alto - 70, 65):
+        cv2.line(imaxe, (35, y), (ancho - 35, y), (40, 40, 40), 3)
+    for x in (100, 210, 335, 450):
+        cv2.line(imaxe, (x, 100), (x, alto - 75), (70, 70, 70), 2)
+    cv2.putText(
+        imaxe,
+        "PAUTA DE TRATAMENTO",
+        (45, 65),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.75,
+        (20, 20, 20),
+        2,
+        cv2.LINE_AA,
+    )
+    return imaxe
+
+
+def _rotar(imaxe: np.ndarray, angulo: float) -> np.ndarray:
+    alto, ancho = imaxe.shape[:2]
+    centro = (ancho / 2.0, alto / 2.0)
+    matriz = cv2.getRotationMatrix2D(centro, angulo, 1.0)
+    coseno = abs(matriz[0, 0])
+    seno = abs(matriz[0, 1])
+    novo_ancho = int(np.ceil(alto * seno + ancho * coseno))
+    novo_alto = int(np.ceil(alto * coseno + ancho * seno))
+    matriz[0, 2] += novo_ancho / 2.0 - centro[0]
+    matriz[1, 2] += novo_alto / 2.0 - centro[1]
+    return cv2.warpAffine(
+        imaxe,
+        matriz,
+        (novo_ancho, novo_alto),
+        flags=cv2.INTER_CUBIC,
+        borderValue=(75, 75, 75),
+    )
+
+
+class TestPreprocesamento(unittest.TestCase):
+    def test_pdf_pasa_byte_a_byte_sen_cambios(self):
+        pdf = b"%PDF-1.7\ncontido de proba"
+
+        resultado = preprocesar_documento(pdf, "application/octet-stream", activado=True)
+
+        self.assertFalse(resultado.aplicado)
+        self.assertEqual(resultado.motivo, "pdf")
+        self.assertIs(resultado.contido, pdf)
+
+    def test_heif_non_se_modifica(self):
+        heif = b"\x00\x00\x00\x18ftypheic" + b"datos"
+
+        resultado = preprocesar_documento(heif, "image/heic", activado=True)
+
+        self.assertFalse(resultado.aplicado)
+        self.assertEqual(resultado.contido, heif)
+
+    def test_bytes_invalidos_non_bloquean_o_ocr(self):
+        entrada = b"non e unha imaxe"
+
+        resultado = preprocesar_documento(entrada, "image/jpeg", activado=True)
+
+        self.assertFalse(resultado.aplicado)
+        self.assertEqual(resultado.contido, entrada)
+
+    def test_unha_imaxe_recta_non_se_recomprime(self):
+        entrada = _codificar(_crear_folla())
+
+        resultado = preprocesar_documento(entrada, "image/png", activado=True)
+
+        self.assertFalse(resultado.aplicado)
+        self.assertEqual(resultado.contido, entrada)
+
+    def test_corrixe_unha_inclinacion_moderada(self):
+        entrada = _codificar(_rotar(_crear_folla(), 7.0))
+
+        resultado = preprocesar_documento(entrada, "image/png", activado=True)
+
+        self.assertTrue(resultado.aplicado)
+        self.assertIn(resultado.metodo, {"perspectiva", "inclinacion"})
+        self.assertGreater(resultado.confianza, 0.7)
+        self.assertNotEqual(resultado.contido, entrada)
+
+        segunda_pasada = preprocesar_documento(
+            resultado.contido,
+            "image/png",
+            activado=True,
+        )
+        self.assertFalse(segunda_pasada.aplicado)
+
+    def test_corrixe_perspectiva_cando_detecta_os_catro_bordos(self):
+        folla = _crear_folla(500, 700)
+        orixe = np.float32([[0, 0], [499, 0], [499, 699], [0, 699]])
+        destino = np.float32([[145, 75], [655, 125], [620, 820], [90, 765]])
+        matriz = cv2.getPerspectiveTransform(orixe, destino)
+        deformada = cv2.warpPerspective(
+            folla,
+            matriz,
+            (760, 900),
+            flags=cv2.INTER_CUBIC,
+            borderValue=(65, 65, 65),
+        )
+        entrada = _codificar(deformada)
+
+        resultado = preprocesar_documento(entrada, "image/png", activado=True)
+
+        self.assertTrue(resultado.aplicado)
+        self.assertEqual(resultado.metodo, "perspectiva")
+
+    def test_sen_catro_bordos_non_inventa_un_recorte(self):
+        sen_bordo = _crear_folla(con_bordo=False)
+        inclinada = _rotar(sen_bordo, -6.0)
+        recortada = inclinada[:, 75:-75]
+        entrada = _codificar(recortada)
+
+        resultado = preprocesar_documento(entrada, "image/png", activado=True)
+
+        self.assertTrue(resultado.aplicado)
+        self.assertEqual(resultado.metodo, "inclinacion")
+        self.assertGreaterEqual(resultado.dimensions_saida[0], resultado.dimensions_orixinais[0])
+        self.assertGreaterEqual(resultado.dimensions_saida[1], resultado.dimensions_orixinais[1])
+
+        segunda_pasada = preprocesar_documento(
+            resultado.contido,
+            "image/png",
+            activado=True,
+        )
+        self.assertFalse(segunda_pasada.aplicado)
+        self.assertEqual(segunda_pasada.contido, resultado.contido)
+
+    def test_non_confunde_un_panel_interno_co_bordo_do_papel(self):
+        panel = _crear_folla(600, 760)
+        panel = (panel.astype(np.float32) * 0.92).astype(np.uint8)
+        orixe = np.float32([[0, 0], [599, 0], [599, 759], [0, 759]])
+        destino = np.float32([[120, 95], [718, 147], [650, 905], [54, 853]])
+        matriz = cv2.getPerspectiveTransform(orixe, destino)
+        imaxe = cv2.warpPerspective(
+            panel,
+            matriz,
+            (800, 1000),
+            borderValue=(255, 255, 255),
+        )
+        entrada = _codificar(imaxe)
+
+        resultado = preprocesar_documento(entrada, "image/png", activado=True)
+
+        self.assertNotEqual(resultado.metodo, "perspectiva")
+        if resultado.aplicado:
+            self.assertEqual(resultado.metodo, "inclinacion")
+            self.assertGreaterEqual(resultado.dimensions_saida[0], resultado.dimensions_orixinais[0])
+            self.assertGreaterEqual(resultado.dimensions_saida[1], resultado.dimensions_orixinais[1])
+
+    def test_conserva_o_orixinal_se_a_saida_supera_o_limite(self):
+        inclinada = _rotar(_crear_folla(), 7.0)
+        correcto, datos = cv2.imencode(
+            ".jpg",
+            inclinada,
+            [cv2.IMWRITE_JPEG_QUALITY, 60],
+        )
+        self.assertTrue(correcto)
+        entrada = datos.tobytes()
+
+        with patch.dict(os.environ, {"PREPROCESS_MAX_BYTES": "90000"}):
+            resultado = preprocesar_documento(entrada, "image/jpeg", activado=True)
+
+        self.assertFalse(resultado.aplicado)
+        self.assertEqual(resultado.contido, entrada)
+        self.assertLessEqual(len(resultado.contido), 90000)
+
+    def test_non_expande_a_rotacion_por_riba_do_limite(self):
+        sen_bordo = _crear_folla(con_bordo=False)
+        inclinada = _rotar(sen_bordo, -6.0)[:, 75:-75]
+        entrada = _codificar(inclinada)
+
+        with patch("app.internal.preprocesamento.MAX_LADO_AZURE", 820):
+            resultado = preprocesar_documento(entrada, "image/png", activado=True)
+
+        self.assertFalse(resultado.aplicado)
+        self.assertEqual(resultado.contido, entrada)
+        self.assertEqual(resultado.motivo, "saida_supera_limite_de_dimensions")
+
+    def test_podese_desactivar_sen_modificar_a_entrada(self):
+        entrada = _codificar(_rotar(_crear_folla(), 8.0))
+
+        resultado = preprocesar_documento(entrada, "image/png", activado=False)
+
+        self.assertFalse(resultado.aplicado)
+        self.assertEqual(resultado.motivo, "desactivado")
+        self.assertEqual(resultado.contido, entrada)
+
+
+class TestIntegracionPreprocesamentoAPI(unittest.TestCase):
+    def setUp(self):
+        self.cliente_azure = MagicMock()
+        app.state.doc_intel_client = self.cliente_azure
+        self.cliente = TestClient(app)
+
+    @patch("app.routers.extraccion.preprocesar_documento")
+    def test_a_api_envia_a_azure_a_imaxe_preprocesada(self, preprocesar_mock):
+        preprocesar_mock.return_value = ResultadoPreprocesamento(
+            contido=b"imaxe procesada",
+            aplicado=True,
+            metodo="inclinacion",
+            motivo="proba",
+        )
+        resultado_azure = MagicMock()
+        resultado_azure.documents = []
+        self.cliente_azure.begin_analyze_document.return_value.result.return_value = resultado_azure
+
+        resposta = self.cliente.post(
+            "/extraccion/",
+            files={"file": ("informe.jpg", b"imaxe orixinal", "image/jpeg")},
+        )
+
+        self.assertEqual(resposta.status_code, 400)
+        chamada = self.cliente_azure.begin_analyze_document.call_args
+        self.assertEqual(chamada.kwargs["body"], b"imaxe procesada")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/test/test_preprocesamento.py
+++ b/server/test/test_preprocesamento.py
@@ -108,6 +108,38 @@ class TestPreprocesamento(unittest.TestCase):
         )
         self.assertFalse(segunda_pasada.aplicado)
 
+    def test_corrixe_unha_inclinacion_superior_a_quince_graos(self):
+        entrada = _codificar(_rotar(_crear_folla(), 24.0))
+
+        resultado = preprocesar_documento(entrada, "image/png", activado=True)
+
+        self.assertTrue(resultado.aplicado)
+        self.assertGreater(abs(resultado.angulo), 15.0)
+        self.assertLessEqual(abs(resultado.angulo), 30.0)
+
+    def test_detecta_unha_folla_clara_sobre_un_fondo_con_cor(self):
+        folla = _crear_folla(430, 610)
+        orixe = np.float32([[0, 0], [429, 0], [429, 609], [0, 609]])
+        destino = np.float32([[230, 120], [670, 245], [520, 855], [75, 710]])
+        matriz = cv2.getPerspectiveTransform(orixe, destino)
+        fondo = np.full((940, 760, 3), (55, 105, 150), dtype=np.uint8)
+        deformada = cv2.warpPerspective(
+            folla,
+            matriz,
+            (760, 940),
+            dst=fondo,
+            borderMode=cv2.BORDER_TRANSPARENT,
+        )
+        entrada = _codificar(deformada, ".jpg")
+
+        with patch("app.internal.preprocesamento._buscar_folla", return_value=None):
+            resultado = preprocesar_documento(entrada, "image/jpeg", activado=True)
+
+        self.assertTrue(resultado.aplicado)
+        self.assertEqual(resultado.metodo, "perspectiva")
+        self.assertEqual(resultado.motivo, "silueta_clara_da_folla")
+        self.assertLess(len(resultado.contido), len(entrada))
+
     def test_corrixe_perspectiva_cando_detecta_os_catro_bordos(self):
         folla = _crear_folla(500, 700)
         orixe = np.float32([[0, 0], [499, 0], [499, 699], [0, 699]])
@@ -148,6 +180,30 @@ class TestPreprocesamento(unittest.TestCase):
         self.assertFalse(segunda_pasada.aplicado)
         self.assertEqual(segunda_pasada.contido, resultado.contido)
 
+    def test_un_xiro_amplo_reduce_o_recheo_sen_recortar_en_exceso(self):
+        sen_bordo = _crear_folla(con_bordo=False)
+        inclinada = _rotar(sen_bordo, -24.0)
+        entrada = _codificar(inclinada)
+
+        with patch("app.internal.preprocesamento._buscar_folla", return_value=None), patch(
+            "app.internal.preprocesamento._buscar_folla_clara",
+            return_value=None,
+        ):
+            resultado = preprocesar_documento(entrada, "image/png", activado=True)
+
+        self.assertTrue(resultado.aplicado)
+        self.assertEqual(resultado.metodo, "inclinacion")
+        ancho, alto = resultado.dimensions_orixinais
+        radians = np.radians(resultado.angulo)
+        ancho_expandido = int(np.ceil(alto * abs(np.sin(radians)) + ancho * abs(np.cos(radians))))
+        alto_expandido = int(np.ceil(alto * abs(np.cos(radians)) + ancho * abs(np.sin(radians))))
+        self.assertLess(
+            resultado.dimensions_saida[0] * resultado.dimensions_saida[1],
+            ancho_expandido * alto_expandido,
+        )
+        self.assertGreaterEqual(resultado.dimensions_saida[0], 0.72 * ancho)
+        self.assertGreaterEqual(resultado.dimensions_saida[1], 0.72 * alto)
+
     def test_non_confunde_un_panel_interno_co_bordo_do_papel(self):
         panel = _crear_folla(600, 760)
         panel = (panel.astype(np.float32) * 0.92).astype(np.uint8)
@@ -180,12 +236,35 @@ class TestPreprocesamento(unittest.TestCase):
         self.assertTrue(correcto)
         entrada = datos.tobytes()
 
-        with patch.dict(os.environ, {"PREPROCESS_MAX_BYTES": "90000"}):
+        limite = len(entrada) + 100
+        with patch.dict(os.environ, {"PREPROCESS_MAX_BYTES": str(limite)}):
             resultado = preprocesar_documento(entrada, "image/jpeg", activado=True)
 
         self.assertFalse(resultado.aplicado)
         self.assertEqual(resultado.contido, entrada)
-        self.assertLessEqual(len(resultado.contido), 90000)
+        self.assertLessEqual(len(resultado.contido), limite)
+
+    def test_pode_reducir_unha_entrada_maior_ca_o_limite(self):
+        folla = _crear_folla(430, 610)
+        orixe = np.float32([[0, 0], [429, 0], [429, 609], [0, 609]])
+        destino = np.float32([[210, 105], [665, 205], [540, 845], [85, 710]])
+        matriz = cv2.getPerspectiveTransform(orixe, destino)
+        deformada = cv2.warpPerspective(
+            folla,
+            matriz,
+            (760, 940),
+            borderValue=(65, 110, 155),
+        )
+        jpeg = _codificar(deformada, ".jpg")
+        entrada = jpeg + b"datos-de-recheo" * 20_000
+        limite = len(jpeg) + 40_000
+        self.assertGreater(len(entrada), limite)
+
+        with patch.dict(os.environ, {"PREPROCESS_MAX_BYTES": str(limite)}):
+            resultado = preprocesar_documento(entrada, "image/jpeg", activado=True)
+
+        self.assertTrue(resultado.aplicado)
+        self.assertLessEqual(len(resultado.contido), limite)
 
     def test_non_expande_a_rotacion_por_riba_do_limite(self):
         sen_bordo = _crear_folla(con_bordo=False)


### PR DESCRIPTION
## Que cambia

- Engade un preprocesamento conservador para fotografías JPEG e PNG antes do OCR.
- Corrixe a perspectiva cando se detecta a folla con suficiente confianza.
- Se non se identifican con claridade os catro bordos, corrixe só a inclinación mediante as liñas consistentes.
- Recorta de forma conservadora o recheo branco xerado ao xirar, sen eliminar contido útil.
- Mantén sen cambios os PDF, HEIC/HEIF, imaxes xa rectas e casos dubidosos.
- Conserva a calidade e adapta a codificación só cando é necesario respectar os límites do servizo.
- Inclúe unha ferramenta local para revisar o resultado nun directorio ignorado por Git.

## Comprobacións realizadas

- [x] 42 probas automáticas correctas.
- [x] Casos rectos, inclinados, con perspectiva, sen os catro bordos, con paneis internos e con límites de tamaño.
- [x] PDF enviados byte a byte sen modificacións.
- [x] Validación local con seis fotografías reais; as imaxes non se incorporaron ao repositorio.
- [x] Comparación da extracción con e sen preprocesamento.
- [x] Mellora da confianza nunha mostra con perspectiva, aproximadamente de 0,900 a 0,931.
- [x] Resultado correcto nunha mostra con bordos ambiguos, mantendo o calendario e o histórico extraídos.
- [x] Sen regresións nas fotografías xa rectas.
- [x] Saída temporal de diagnóstico retirada do fluxo da API; os ficheiros locais permanecen ignorados por Git.

Closes #62
