### PR TITLE
Corrixir a navegación e os recordatorios

### DIFF
--- a/client/lib/compoñentes/barra_navegacion_inferior.dart
+++ b/client/lib/compoñentes/barra_navegacion_inferior.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart'; // Barra de navegación principal.
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import '../views/calendario.dart';
-import '../views/camara/captura_informe.dart';
 import '../views/progreso.dart';
 
 class AppBottomNav extends StatefulWidget {
@@ -42,7 +41,7 @@ class _AppBottomNavState extends State<AppBottomNav> {
         } else if (destino == 1) {
           Navigator.pushReplacement(context, MaterialPageRoute(builder: (_) => const ProgressScreen()));
         } else if (destino == 2) {
-          await Navigator.push(context, MaterialPageRoute(builder: (_) => const CapturaInformeScreen()));
+          await Navigator.pushNamed(context, '/captura');
         } else if (destino == 3) {
           Navigator.pushReplacement(context, MaterialPageRoute(builder: (_) => const TreatmentCalendarScreen()));
         }

--- a/client/lib/main.dart
+++ b/client/lib/main.dart
@@ -20,6 +20,7 @@ import 'views/autenticacion/vinculacion_coidador.dart';
 import 'views/autenticacion/vinculacion_paciente.dart';
 import 'views/autenticacion/configuracion_adicional.dart';
 import 'views/inicio_coidador.dart';
+import 'views/camara/captura_informe.dart';
 import 'servizos/servizo_sincronizacion_p2p.dart';
 import 'servizos/servizo_notificacions_locais.dart';
 import 'servizos/servizo_base_datos.dart';
@@ -52,8 +53,7 @@ void main() async {
     final hora = await storage.read(key: 'hora_toma');
     final nome = await storage.read(key: 'nome_usuario') ?? '';
     if (hora != null) {
-      await LocalNotificationService().programarTomas(
-        identificador: 'paciente_local',
+      await LocalNotificationService().programarTomasPaciente(
         nome: nome,
         hora: hora,
       );
@@ -62,8 +62,6 @@ void main() async {
       if (estados[hoxe] == 'TOMADA' || estados[hoxe] == 'TOMADA_FORA_HORA') {
         await LocalNotificationService().cancelarEsquecementoHoxe(
           identificador: 'paciente_local',
-          nome: nome,
-          hora: hora,
         );
       }
     }
@@ -117,6 +115,7 @@ class MyApp extends StatelessWidget {
         '/configuracion_adicional': (context) => const AdditionalSettingsScreen(),
         '/home': (context) => const PacienteHomeScreen(),
         '/coidador': (context) => const CaregiverHomeScreen(),
+        '/captura': (context) => const CapturaInformeScreen(),
 
       },
     );

--- a/client/lib/modelos_vista/inicio.dart
+++ b/client/lib/modelos_vista/inicio.dart
@@ -26,7 +26,9 @@ class HomeViewModel extends ChangeNotifier {
   List<PautaToma> pautaSemanal = [];
 
   String get doseHoxe {
-    if (_ultimaAnalise == null || _ultimaAnalise!.calendario.isEmpty) return "--";
+    if (_ultimaAnalise == null || _ultimaAnalise!.calendario.isEmpty) {
+      return "--";
+    }
     return tomaHoxe?.dose ?? "--";
   }
 
@@ -35,7 +37,8 @@ class HomeViewModel extends ChangeNotifier {
     notifyListeners();
 
     try {
-      await DatabaseService().pecharTomasVencidas();
+      final novasTomasEsquecidas =
+          await DatabaseService().pecharTomasVencidas();
       final pautaBD = await DatabaseService().obterPauta();
       final estados = await DatabaseService().obterEstados();
       _cabeceira = await DatabaseService().obterCabeceira();
@@ -62,6 +65,10 @@ class HomeViewModel extends ChangeNotifier {
           calendario: pautaBD,
           historico: [],
         );
+      }
+
+      if (novasTomasEsquecidas.isNotEmpty) {
+        await P2PSyncService().notificarCoidador('TOMA_ESQUECIDA');
       }
 
     } catch (e) {
@@ -101,8 +108,6 @@ class HomeViewModel extends ChangeNotifier {
     if (hora != null) {
       await LocalNotificationService().cancelarEsquecementoHoxe(
         identificador: 'paciente_local',
-        nome: await storage.read(key: 'nome_usuario') ?? '',
-        hora: hora,
       );
     }
   }

--- a/client/lib/servizos/planificador_recordatorios.dart
+++ b/client/lib/servizos/planificador_recordatorios.dart
@@ -1,0 +1,97 @@
+enum TipoRecordatorioToma { toma, esquecemento }
+
+class RecordatorioToma {
+  const RecordatorioToma({
+    required this.data,
+    required this.instante,
+    required this.tipo,
+  });
+
+  final String data;
+  final DateTime instante;
+  final TipoRecordatorioToma tipo;
+}
+
+class PlanificadorRecordatorios {
+  const PlanificadorRecordatorios._();
+
+  static bool eDoseTomable(Object? dose) {
+    final valor = dose?.toString().trim().toUpperCase().replaceAll(',', '.');
+    if (valor == null || valor.isEmpty || valor == 'CTRL' || valor == 'NON') {
+      return false;
+    }
+    if (valor.contains('/')) {
+      final partes = valor.split('/');
+      final numerador = double.tryParse(partes.first);
+      final denominador = double.tryParse(partes.last);
+      return numerador != null &&
+          denominador != null &&
+          denominador != 0 &&
+          numerador != 0;
+    }
+    return double.tryParse(valor) != 0;
+  }
+
+  static List<RecordatorioToma> crear({
+    required DateTime agora,
+    required String hora,
+    required Iterable<String> datasConToma,
+    Map<String, String> estados = const {},
+    int marxeEsquecementoMinutos = 30,
+  }) {
+    final partesHora = hora.split(':');
+    if (partesHora.length != 2) return const [];
+    final horaNumero = int.tryParse(partesHora[0]);
+    final minutoNumero = int.tryParse(partesHora[1]);
+    if (horaNumero == null ||
+        minutoNumero == null ||
+        horaNumero < 0 ||
+        horaNumero > 23 ||
+        minutoNumero < 0 ||
+        minutoNumero > 59) {
+      return const [];
+    }
+
+    final resultado = <RecordatorioToma>[];
+    final datasOrdenadas = datasConToma.toSet().toList()..sort();
+    for (final data in datasOrdenadas) {
+      if (_estadoPechado(estados[data])) continue;
+      final partesData = data.split('-');
+      if (partesData.length != 3) continue;
+      final ano = int.tryParse(partesData[0]);
+      final mes = int.tryParse(partesData[1]);
+      final dia = int.tryParse(partesData[2]);
+      if (ano == null || mes == null || dia == null) continue;
+
+      final toma = DateTime(ano, mes, dia, horaNumero, minutoNumero);
+      if (toma.year != ano || toma.month != mes || toma.day != dia) continue;
+      final esquecemento = toma.add(
+        Duration(minutes: marxeEsquecementoMinutos),
+      );
+      if (toma.isAfter(agora)) {
+        resultado.add(
+          RecordatorioToma(
+            data: data,
+            instante: toma,
+            tipo: TipoRecordatorioToma.toma,
+          ),
+        );
+      }
+      if (esquecemento.isAfter(agora)) {
+        resultado.add(
+          RecordatorioToma(
+            data: data,
+            instante: esquecemento,
+            tipo: TipoRecordatorioToma.esquecemento,
+          ),
+        );
+      }
+    }
+    return resultado;
+  }
+
+  static bool _estadoPechado(String? estado) =>
+      estado == 'TOMADA' ||
+      estado == 'TOMADA_FORA_HORA' ||
+      estado == 'NON_TOMADA';
+}

--- a/client/lib/servizos/servizo_base_datos.dart
+++ b/client/lib/servizos/servizo_base_datos.dart
@@ -290,15 +290,29 @@ class DatabaseService {
     }, where: 'data = ?', whereArgs: [data]);
   }
 
-  Future<void> pecharTomasVencidas() async {
+  Future<List<String>> pecharTomasVencidas() async {
     final db = await database;
     final hoxe = DateTime.now().toIso8601String().substring(0, 10);
-    await db.update(
-      'pautas',
-      {'estado': 'NON_TOMADA'},
-      where: "data < ? AND estado = 'PENDENTE' AND eControl = 0 AND dose != '0'",
-      whereArgs: [hoxe],
-    );
+    return db.transaction((txn) async {
+      final vencidas = await txn.query(
+        'pautas',
+        columns: ['id', 'data'],
+        where: "data < ? AND estado = 'PENDENTE' AND eControl = 0 "
+            "AND UPPER(TRIM(COALESCE(dose, ''))) "
+            "NOT IN ('', '0', '0.0', '0,0', 'NON', 'CTRL')",
+        whereArgs: [hoxe],
+      );
+      if (vencidas.isEmpty) return <String>[];
+      final ids = vencidas.map((fila) => fila['id'] as int).toList();
+      final marcadores = List.filled(ids.length, '?').join(',');
+      await txn.update(
+        'pautas',
+        {'estado': 'NON_TOMADA'},
+        where: 'id IN ($marcadores)',
+        whereArgs: ids,
+      );
+      return vencidas.map((fila) => fila['data'] as String).toList();
+    });
   }
 
   Future<List<Map<String, Object?>>> obterRexistrosCumprimento() async {

--- a/client/lib/servizos/servizo_notificacions_locais.dart
+++ b/client/lib/servizos/servizo_notificacions_locais.dart
@@ -2,9 +2,12 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart'; /
 import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:timezone/data/latest.dart' as tz_data;
 import 'package:timezone/timezone.dart' as tz;
+import 'servizo_base_datos.dart';
+import 'planificador_recordatorios.dart';
 
 class LocalNotificationService {
-  static final LocalNotificationService _instance = LocalNotificationService._internal();
+  static final LocalNotificationService _instance =
+      LocalNotificationService._internal();
   factory LocalNotificationService() => _instance;
   LocalNotificationService._internal();
 
@@ -41,71 +44,109 @@ class LocalNotificationService {
         iOS: DarwinInitializationSettings(),
       ),
     );
-    final android = _plugin.resolvePlatformSpecificImplementation<
-        AndroidFlutterLocalNotificationsPlugin>();
+    final android = _plugin
+        .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin
+        >();
     await android?.requestNotificationsPermission();
     await android?.requestExactAlarmsPermission();
     _inicializado = true;
   }
 
-  int _baseId(String identificador) => identificador.codeUnits.fold<int>(0, (a, b) => (a * 31 + b) & 0x3fffffff) % 100000 * 10;
+  int _baseId(String identificador) =>
+      identificador.codeUnits.fold<int>(
+        0,
+        (a, b) => (a * 31 + b) & 0x3fffffff,
+      ) %
+      100000 *
+      10;
+
+  int _idData(String identificador, String data, TipoRecordatorioToma tipo) {
+    final valor = '$identificador|$data|${tipo.name}';
+    return valor.codeUnits.fold<int>(
+      0,
+      (anterior, actual) => (anterior * 31 + actual) & 0x7fffffff,
+    );
+  }
+
+  Future<void> programarTomasPaciente({
+    required String nome,
+    required String hora,
+  }) async {
+    final pauta = await DatabaseService().obterPauta();
+    final estados = await DatabaseService().obterEstados();
+    await programarTomas(
+      identificador: 'paciente_local',
+      nome: nome,
+      hora: hora,
+      datasConToma: pauta
+          .where(
+            (dia) =>
+                !dia.eControl &&
+                PlanificadorRecordatorios.eDoseTomable(dia.dose),
+          )
+          .map((dia) => dia.data),
+      estados: estados,
+    );
+  }
 
   Future<void> programarTomas({
     required String identificador,
     required String nome,
     required String hora,
+    required Iterable<String> datasConToma,
+    Map<String, String> estados = const {},
     int marxeEsquecementoMinutos = 30,
-    bool desdeManha = false,
   }) async {
     await inicializar();
-    final partes = hora.split(':');
-    if (partes.length != 2) return;
-    final h = int.tryParse(partes[0]);
-    final m = int.tryParse(partes[1]);
-    if (h == null || m == null) return;
-    final base = _baseId(identificador);
-    await _plugin.cancel(id: base);
-    await _plugin.cancel(id: base + 1);
-    final agora = tz.TZDateTime.now(tz.local);
-    final dataBase = desdeManha ? agora.add(const Duration(days: 1)) : agora;
-    var toma = tz.TZDateTime(tz.local, dataBase.year, dataBase.month, dataBase.day, h, m);
-    if (!toma.isAfter(agora)) toma = toma.add(const Duration(days: 1));
-    final esquecemento = toma.add(Duration(minutes: marxeEsquecementoMinutos));
-    await _plugin.zonedSchedule(
-      id: base,
-      title: 'Hora da toma',
-      body: nome.isEmpty ? 'É hora de tomar a medicación.' : '$nome: é hora de tomar a medicación.',
-      scheduledDate: toma,
-      notificationDetails: _details,
-      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
-      matchDateTimeComponents: DateTimeComponents.time,
-      payload: 'toma:$identificador',
+    await cancelarTomas(identificador);
+    final agora = DateTime.now();
+    final recordatorios = PlanificadorRecordatorios.crear(
+      agora: agora,
+      hora: hora,
+      datasConToma: datasConToma,
+      estados: estados,
+      marxeEsquecementoMinutos: marxeEsquecementoMinutos,
     );
-    await _plugin.zonedSchedule(
-      id: base + 1,
-      title: 'Toma sen confirmar',
-      body: nome.isEmpty ? 'A toma segue pendente de confirmar.' : 'A toma de $nome segue pendente de confirmar.',
-      scheduledDate: esquecemento,
-      notificationDetails: _details,
-      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
-      matchDateTimeComponents: DateTimeComponents.time,
-      payload: 'esquecemento:$identificador',
-    );
+    for (final recordatorio in recordatorios) {
+      final eToma = recordatorio.tipo == TipoRecordatorioToma.toma;
+      final instante = recordatorio.instante;
+      await _plugin.zonedSchedule(
+        id: _idData(identificador, recordatorio.data, recordatorio.tipo),
+        title: eToma ? 'Hora da toma' : 'Toma sen confirmar',
+        body: eToma
+            ? (nome.isEmpty
+                  ? 'É hora de tomar a medicación.'
+                  : '$nome: é hora de tomar a medicación.')
+            : (nome.isEmpty
+                  ? 'A toma segue pendente de confirmar.'
+                  : 'A toma de $nome segue pendente de confirmar.'),
+        scheduledDate: tz.TZDateTime(
+          tz.local,
+          instante.year,
+          instante.month,
+          instante.day,
+          instante.hour,
+          instante.minute,
+        ),
+        notificationDetails: _details,
+        androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+        payload: eToma
+            ? 'toma:$identificador:${recordatorio.data}'
+            : 'esquecemento:$identificador:${recordatorio.data}',
+      );
+    }
   }
 
-  Future<void> cancelarEsquecementoHoxe({
-    required String identificador,
-    required String nome,
-    required String hora,
-  }) async {
+  Future<void> cancelarEsquecementoHoxe({required String identificador}) async {
     await inicializar();
-    await _plugin.cancel(id: _baseId(identificador) + 1);
-    // Reprograma a serie desde mañá para non perder os avisos dos días seguintes.
-    await programarTomas(
-      identificador: identificador,
-      nome: nome,
-      hora: hora,
-      desdeManha: true,
+    final agora = DateTime.now();
+    final hoxe =
+        '${agora.year.toString().padLeft(4, '0')}-'
+        '${agora.month.toString().padLeft(2, '0')}-'
+        '${agora.day.toString().padLeft(2, '0')}';
+    await _plugin.cancel(
+      id: _idData(identificador, hoxe, TipoRecordatorioToma.esquecemento),
     );
   }
 
@@ -114,5 +155,13 @@ class LocalNotificationService {
     final base = _baseId(identificador);
     await _plugin.cancel(id: base);
     await _plugin.cancel(id: base + 1);
+    final pendentes = await _plugin.pendingNotificationRequests();
+    for (final peticion in pendentes) {
+      final payload = peticion.payload;
+      if (payload?.startsWith('toma:$identificador:') == true ||
+          payload?.startsWith('esquecemento:$identificador:') == true) {
+        await _plugin.cancel(id: peticion.id);
+      }
+    }
   }
 }

--- a/client/lib/servizos/servizo_sincronizacion_p2p.dart
+++ b/client/lib/servizos/servizo_sincronizacion_p2p.dart
@@ -7,6 +7,7 @@ import 'servizo_api.dart';
 import 'servizo_base_datos.dart';
 import '../modelos/analise.dart';
 import 'servizo_notificacions_locais.dart';
+import 'planificador_recordatorios.dart';
 
 class P2PSyncService {
   static final P2PSyncService _instance = P2PSyncService._internal();
@@ -54,7 +55,10 @@ class P2PSyncService {
     if (tipo == 'SOLICITAR_SINCRONIZACION') {
       final tokenResposta = payload['tokenResposta'] as String?;
       if (tokenResposta != null) await enviarEstadoCompleto(tokenResposta);
-    } else if (tipo == 'ESTADO_COMPLETO' || tipo == 'TOMA_CONFIRMADA' || tipo == 'NOVO_INFORME') {
+    } else if (tipo == 'ESTADO_COMPLETO' ||
+        tipo == 'TOMA_CONFIRMADA' ||
+        tipo == 'TOMA_ESQUECIDA' ||
+        tipo == 'NOVO_INFORME') {
       final uid = payload['pacienteUid'] as String?;
       final token = payload['tokenPaciente'] as String?;
       if (uid != null && token != null) {
@@ -62,19 +66,23 @@ class P2PSyncService {
         final hora = payload['horaToma'] as String?;
         if (hora != null) {
           final nomePaciente = (payload['nome'] as String?) ?? 'Persoa supervisada';
-          if (tipo == 'TOMA_CONFIRMADA') {
-            await LocalNotificationService().cancelarEsquecementoHoxe(
-              identificador: 'coidador_$uid',
-              nome: nomePaciente,
-              hora: hora,
-            );
-          } else {
-            await LocalNotificationService().programarTomas(
-              identificador: 'coidador_$uid',
-              nome: nomePaciente,
-              hora: hora,
-            );
+          final hoxe = DateTime.now().toIso8601String().substring(0, 10);
+          final datasConToma = (payload['datasConToma'] as List?)
+                  ?.whereType<String>()
+                  .toList() ??
+              <String>[];
+          if (datasConToma.isEmpty &&
+              PlanificadorRecordatorios.eDoseTomable(payload['doseHoxe'])) {
+            datasConToma.add(hoxe);
           }
+          final estadoHoxe = payload['estadoHoxe'] as String?;
+          await LocalNotificationService().programarTomas(
+            identificador: 'coidador_$uid',
+            nome: nomePaciente,
+            hora: hora,
+            datasConToma: datasConToma,
+            estados: estadoHoxe == null ? const {} : {hoxe: estadoHoxe},
+          );
         }
         _actualizacions.add('coidador:$uid');
       }
@@ -88,8 +96,7 @@ class P2PSyncService {
       }
       if (hora != null) await _storage.write(key: 'hora_toma', value: hora);
       if (hora != null) {
-        await LocalNotificationService().programarTomas(
-          identificador: 'paciente_local',
+        await LocalNotificationService().programarTomasPaciente(
           nome: nome ?? '',
           hora: hora,
         );
@@ -110,7 +117,13 @@ class P2PSyncService {
     final token = await FirebaseMessaging.instance.getToken();
     final uid = FirebaseAuth.instance.currentUser?.uid ?? '';
     final hoxe = DateTime.now().toIso8601String().substring(0, 10);
-    final tomables = pauta.where((d) => !d.eControl && d.dose != '0').toList();
+    final tomables = pauta
+        .where(
+          (d) =>
+              !d.eControl &&
+              PlanificadorRecordatorios.eDoseTomable(d.dose),
+        )
+        .toList();
     bool eTomada(String? estado) => estado == 'TOMADA' || estado == 'TOMADA_FORA_HORA';
     final tomadas = tomables.where((d) => eTomada(estados[d.data])).length;
     final esquecidas = tomables.where((d) => !eTomada(estados[d.data]) && d.data.compareTo(hoxe) < 0).length;
@@ -124,6 +137,10 @@ class P2PSyncService {
       'tenInforme': pauta.isNotEmpty,
       'doseHoxe': hoxeDose?.eControl == true ? 'CTRL' : hoxeDose?.dose,
       'estadoHoxe': hoxeDose == null ? null : (estados[hoxe] ?? 'PENDENTE'),
+      'datasConToma': tomables
+          .where((dia) => dia.data.compareTo(hoxe) >= 0)
+          .map((dia) => dia.data)
+          .toList(),
       'proximaVisita': cabeceira?.proximaVisita,
       'centro': cabeceira?.centro,
       'inrActual': cabeceira?.inr,
@@ -251,6 +268,13 @@ class P2PSyncService {
     }
     final analise = AnaliseModel.fromJson(jsonDecode(partes.join()) as Map<String, dynamic>);
     await _db.gardarAnalise(analise);
+    final hora = await _storage.read(key: 'hora_toma');
+    if (hora != null) {
+      await LocalNotificationService().programarTomasPaciente(
+        nome: await _storage.read(key: 'nome_usuario') ?? '',
+        hora: hora,
+      );
+    }
     for (var i = 0; i < total; i++) {
       await _storage.delete(key: 'informe_${id}_$i');
     }

--- a/client/lib/views/autenticacion/configuracion_adicional.dart
+++ b/client/lib/views/autenticacion/configuracion_adicional.dart
@@ -51,8 +51,7 @@ class _AdditionalSettingsScreenState extends State<AdditionalSettingsScreen> {
     );
     await _storage.write(key: 'configuracion_finalizada', value: 'true');
     final horaTexto = '${_hora.hour.toString().padLeft(2, '0')}:${_hora.minute.toString().padLeft(2, '0')}';
-    await LocalNotificationService().programarTomas(
-      identificador: 'paciente_local',
+    await LocalNotificationService().programarTomasPaciente(
       nome: nome,
       hora: horaTexto,
     );

--- a/client/lib/views/axustes_paciente.dart
+++ b/client/lib/views/axustes_paciente.dart
@@ -88,8 +88,7 @@ class _AxustesPacienteScreenState extends State<AxustesPacienteScreen> {
     }
     await _storage.write(key: 'hora_toma', value: hora);
     await _storage.write(key: 'modo_sinxelo', value: _modoSinxelo ? 'true' : 'false');
-    await LocalNotificationService().programarTomas(
-      identificador: 'paciente_local',
+    await LocalNotificationService().programarTomasPaciente(
       nome: nome,
       hora: hora,
     );

--- a/client/lib/views/camara/captura_informe.dart
+++ b/client/lib/views/camara/captura_informe.dart
@@ -5,6 +5,9 @@ import 'package:image_picker/image_picker.dart';
 import '../../servizos/servizo_api.dart';
 import '../../servizos/servizo_base_datos.dart';
 import '../../servizos/servizo_sincronizacion_p2p.dart';
+import '../../servizos/servizo_notificacions_locais.dart';
+import '../../compoñentes/barra_navegacion_inferior.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 class CapturaInformeScreen extends StatefulWidget {
   final String? tokenPacienteDestino;
@@ -49,6 +52,14 @@ class _CapturaInformeScreenState extends State<CapturaInformeScreen> {
       final analise = await _api.enviarInforme(ficheiro);
       if (widget.tokenPacienteDestino == null) {
         await DatabaseService().gardarAnalise(analise);
+        const storage = FlutterSecureStorage();
+        final hora = await storage.read(key: 'hora_toma');
+        if (hora != null) {
+          await LocalNotificationService().programarTomasPaciente(
+            nome: await storage.read(key: 'nome_usuario') ?? '',
+            hora: hora,
+          );
+        }
         await P2PSyncService().notificarCoidador('NOVO_INFORME');
       } else {
         await P2PSyncService().enviarInformeRemoto(
@@ -87,6 +98,7 @@ class _CapturaInformeScreenState extends State<CapturaInformeScreen> {
   Widget build(BuildContext context) => Scaffold(
         backgroundColor: const Color(0xFFF8F9FA),
         appBar: AppBar(
+          automaticallyImplyLeading: widget.tokenPacienteDestino != null,
           backgroundColor: const Color(0xFFF8F9FA),
           title: const Text(
             'Engadir un informe',
@@ -188,6 +200,9 @@ class _CapturaInformeScreenState extends State<CapturaInformeScreen> {
             ],
           ),
         ),
+        bottomNavigationBar: widget.tokenPacienteDestino == null
+            ? const AppBottomNav(currentIndex: 2)
+            : null,
       );
 
   Widget _opcion({

--- a/client/lib/views/inicio_paciente.dart
+++ b/client/lib/views/inicio_paciente.dart
@@ -317,7 +317,7 @@ class _PacienteHomeScreenState extends State<PacienteHomeScreen> with WidgetsBin
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text("Pauta semanal", style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20)),
+          const Text("Pauta", style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20)),
           const SizedBox(height: 18),
           vm.pautaSemanal.isEmpty
               ? const Text("Non hai pautas rexistradas. Saca unha foto ao teu informe.")
@@ -714,7 +714,9 @@ class _PacienteHomeScreenState extends State<PacienteHomeScreen> with WidgetsBin
             context,
             MaterialPageRoute(builder: (context) => const CapturaInformeScreen()),
           ).then((_) {
-            if (context.mounted) context.read<HomeViewModel>().cargarDatosHome();
+            if (context.mounted) {
+              context.read<HomeViewModel>().cargarDatosHome();
+            }
           });
         }
         if (destino == 3) {

--- a/client/test/planificador_recordatorios_test.dart
+++ b/client/test/planificador_recordatorios_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tfg_sintrom/servizos/planificador_recordatorios.dart';
+
+void main() {
+  test('identifica correctamente os días nos que non hai toma', () {
+    for (final dose in [null, '', '0', '0.0', '0,0', '0/1', 'NON', 'CTRL']) {
+      expect(
+        PlanificadorRecordatorios.eDoseTomable(dose),
+        isFalse,
+        reason: 'A dose $dose non debe xerar un aviso',
+      );
+    }
+    expect(PlanificadorRecordatorios.eDoseTomable('1/2'), isTrue);
+    expect(PlanificadorRecordatorios.eDoseTomable('1'), isTrue);
+  });
+
+  test('programa avisos unicamente nas datas indicadas', () {
+    final recordatorios = PlanificadorRecordatorios.crear(
+      agora: DateTime(2026, 7, 28, 10),
+      hora: '20:00',
+      datasConToma: const ['2026-07-28', '2026-07-30'],
+    );
+
+    expect(recordatorios, hasLength(4));
+    expect(recordatorios.map((recordatorio) => recordatorio.data).toSet(), {
+      '2026-07-28',
+      '2026-07-30',
+    });
+  });
+
+  test('non recupera recordatorios dun día anterior', () {
+    final recordatorios = PlanificadorRecordatorios.crear(
+      agora: DateTime(2026, 7, 28, 10),
+      hora: '20:00',
+      datasConToma: const ['2026-07-27'],
+    );
+
+    expect(recordatorios, isEmpty);
+  });
+
+  test('unha toma confirmada non conserva avisos dese día', () {
+    final recordatorios = PlanificadorRecordatorios.crear(
+      agora: DateTime(2026, 7, 28, 10),
+      hora: '20:00',
+      datasConToma: const ['2026-07-28', '2026-07-29'],
+      estados: const {'2026-07-28': 'TOMADA'},
+    );
+
+    expect(
+      recordatorios.every((recordatorio) => recordatorio.data == '2026-07-29'),
+      isTrue,
+    );
+  });
+
+  test('despois da hora da toma mantén só o aviso de esquecemento', () {
+    final recordatorios = PlanificadorRecordatorios.crear(
+      agora: DateTime(2026, 7, 28, 20, 10),
+      hora: '20:00',
+      datasConToma: const ['2026-07-28'],
+    );
+
+    expect(recordatorios, hasLength(1));
+    expect(recordatorios.single.tipo, TipoRecordatorioToma.esquecemento);
+    expect(recordatorios.single.instante, DateTime(2026, 7, 28, 20, 30));
+  });
+
+  test('ignora unha hora non válida', () {
+    final recordatorios = PlanificadorRecordatorios.crear(
+      agora: DateTime(2026, 7, 28, 10),
+      hora: '25:00',
+      datasConToma: const ['2026-07-28'],
+    );
+
+    expect(recordatorios, isEmpty);
+  });
+}


### PR DESCRIPTION
Resumo

- Cambia «Pauta semanal» por «Pauta».
- Integra a pantalla de engadir un informe na navegación inferior do paciente e retira a frecha superior nese contexto.
- Conserva a navegación secundaria con frecha cando o coidador carga unha folla para un paciente supervisado.
- Substitúe os recordatorios diarios recorrentes por avisos únicos para as datas reais con toma.
- Exclúe os días con dose cero, sen toma, de control, xa confirmados ou vencidos.
- Cancela só o esquecemento do día confirmado e conserva os avisos futuros.
- Sincroniza co coidador as datas futuras con toma e comunica os novos esquecementos.

Causa

Os recordatorios anteriores repetíanse todos os días á mesma hora e non consultaban a pauta. Isto xeraba falsos avisos nos días sen dose e podía conservar un esquecemento antigo tras cambiar de día.

Comprobacións

- flutter analyze: sen incidencias.
- 6 probas automáticas do planificador superadas.
- APK Android de depuración compilada correctamente.
- google-services.json usado só de maneira local e retirado despois da compilación.
- Pendente validar a navegación nun dispositivo e o fluxo completo de avisos con dous dispositivos Android.

Coordinación

A PR #66 deberá actualizarse despois de integrar esta corrección, porque ambas modifican a sincronización P2P e as notificacións.

Closes #67
Closes #68
Refs #33