### PR TITLE
Revisar a pauta antes de gardar

### DIFF
--- a/client/lib/modelos/revision_pauta.dart
+++ b/client/lib/modelos/revision_pauta.dart
@@ -1,0 +1,165 @@
+import 'analise.dart';
+import 'cabeceira.dart';
+import 'dose_dia.dart';
+
+class RevisionPauta {
+  static const List<String> _diasSemana = [
+    'LUNS',
+    'MARTES',
+    'MÉRCORES',
+    'XOVES',
+    'VENRES',
+    'SÁBADO',
+    'DOMINGO',
+  ];
+
+  static DateTime? interpretarData(String? valor) {
+    final texto = valor?.trim() ?? '';
+    if (texto.isEmpty) return null;
+
+    final iso = RegExp(r'^(\d{4})-(\d{2})-(\d{2})$').firstMatch(texto);
+    if (iso != null) {
+      return _crearDataExacta(
+        int.parse(iso.group(1)!),
+        int.parse(iso.group(2)!),
+        int.parse(iso.group(3)!),
+      );
+    }
+
+    final europea = RegExp(r'^(\d{1,2})/(\d{1,2})/(\d{4})$').firstMatch(texto);
+    if (europea != null) {
+      return _crearDataExacta(
+        int.parse(europea.group(3)!),
+        int.parse(europea.group(2)!),
+        int.parse(europea.group(1)!),
+      );
+    }
+    return null;
+  }
+
+  static DateTime? _crearDataExacta(int ano, int mes, int dia) {
+    if (mes < 1 || mes > 12 || dia < 1 || dia > 31) return null;
+    final data = DateTime(ano, mes, dia);
+    return data.year == ano && data.month == mes && data.day == dia
+        ? data
+        : null;
+  }
+
+  static String formatoIso(DateTime data) =>
+      '${data.year.toString().padLeft(4, '0')}-'
+      '${data.month.toString().padLeft(2, '0')}-'
+      '${data.day.toString().padLeft(2, '0')}';
+
+  static String formatoVisita(DateTime data) =>
+      '${data.day.toString().padLeft(2, '0')}/'
+      '${data.month.toString().padLeft(2, '0')}/'
+      '${data.year.toString().padLeft(4, '0')}';
+
+  static String diaSemana(DateTime data) => _diasSemana[data.weekday - 1];
+
+  static AnaliseModel actualizarDia(
+    AnaliseModel analise,
+    int indice, {
+    DateTime? data,
+    String? dose,
+    bool? eControl,
+  }) {
+    final anterior = analise.calendario[indice];
+    final novaData = data ?? interpretarData(anterior.data)!;
+    final novoControl = eControl ?? anterior.eControl;
+    final novaDose = novoControl ? null : (dose ?? anterior.dose ?? '0').trim();
+    final novaAccion = novoControl
+        ? 'CONTROL'
+        : novaDose == '0'
+        ? 'NON TOMAR'
+        : 'TOMAR';
+
+    final calendario = [...analise.calendario];
+    calendario[indice] = DoseDiaModel(
+      data: formatoIso(novaData),
+      dia: novaData.day,
+      dose: novaDose,
+      accion: novaAccion,
+      eControl: novoControl,
+      diaSemanaTexto: diaSemana(novaData),
+    );
+    return AnaliseModel(
+      cabeceira: analise.cabeceira,
+      calendario: calendario,
+      historico: analise.historico,
+    );
+  }
+
+  static AnaliseModel actualizarProximaVisita(
+    AnaliseModel analise,
+    DateTime? data,
+  ) {
+    final cabeceira = analise.cabeceira;
+    return AnaliseModel(
+      cabeceira: CabeceiraModel(
+        dataInforme: cabeceira.dataInforme,
+        inr: cabeceira.inr,
+        farmaco: cabeceira.farmaco,
+        doseSemanal: cabeceira.doseSemanal,
+        proximaVisita: data == null ? null : formatoVisita(data),
+        centro: cabeceira.centro,
+      ),
+      calendario: analise.calendario,
+      historico: analise.historico,
+    );
+  }
+
+  static AnaliseModel ordenar(AnaliseModel analise) {
+    final calendario = [...analise.calendario]
+      ..sort((a, b) => a.data.compareTo(b.data));
+    return AnaliseModel(
+      cabeceira: analise.cabeceira,
+      calendario: calendario,
+      historico: analise.historico,
+    );
+  }
+
+  static List<String> validar(AnaliseModel analise) {
+    final erros = <String>[];
+    if (analise.calendario.isEmpty) {
+      erros.add('A pauta debe conter polo menos un día.');
+      return erros;
+    }
+
+    final datas = <String>{};
+    for (var i = 0; i < analise.calendario.length; i++) {
+      final dia = analise.calendario[i];
+      if (interpretarData(dia.data) == null) {
+        erros.add('A data da fila ${i + 1} non é válida.');
+      } else if (!datas.add(dia.data)) {
+        erros.add('A data ${dia.data} está repetida.');
+      }
+
+      if (!dia.eControl) {
+        final dose = dia.dose?.trim() ?? '';
+        if (dose.isEmpty) {
+          erros.add('Falta a dose do ${dia.data}.');
+        } else if (!_doseValida(dose)) {
+          erros.add('A dose «$dose» do ${dia.data} non é válida.');
+        }
+      }
+    }
+
+    final visita = analise.cabeceira.proximaVisita?.trim() ?? '';
+    if (visita.isNotEmpty && interpretarData(visita) == null) {
+      erros.add('A data da seguinte visita non é válida.');
+    }
+    return erros;
+  }
+
+  static bool _doseValida(String dose) {
+    final normalizada = dose.replaceAll(' ', '').replaceAll(',', '.');
+    if (RegExp(r'^\d+(?:\.\d+)?$').hasMatch(normalizada)) return true;
+
+    final fraccion = RegExp(
+      r'^(?:(\d+)\+)?(\d+)/(\d+)$',
+    ).firstMatch(normalizada);
+    if (fraccion == null) return false;
+    return int.parse(fraccion.group(3)!) != 0;
+  }
+}

--- a/client/lib/modelos/revision_pauta.dart
+++ b/client/lib/modelos/revision_pauta.dart
@@ -109,6 +109,28 @@ class RevisionPauta {
     );
   }
 
+  static AnaliseModel eliminarDia(AnaliseModel analise, int indice) {
+    final calendario = [...analise.calendario]..removeAt(indice);
+    return AnaliseModel(
+      cabeceira: analise.cabeceira,
+      calendario: calendario,
+      historico: analise.historico,
+    );
+  }
+
+  static AnaliseModel inserirDia(
+    AnaliseModel analise,
+    int indice,
+    DoseDiaModel dia,
+  ) {
+    final calendario = [...analise.calendario]..insert(indice, dia);
+    return AnaliseModel(
+      cabeceira: analise.cabeceira,
+      calendario: calendario,
+      historico: analise.historico,
+    );
+  }
+
   static AnaliseModel ordenar(AnaliseModel analise) {
     final calendario = [...analise.calendario]
       ..sort((a, b) => a.data.compareTo(b.data));

--- a/client/lib/views/camara/captura_informe.dart
+++ b/client/lib/views/camara/captura_informe.dart
@@ -2,9 +2,11 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
+import '../../modelos/analise.dart';
 import '../../servizos/servizo_api.dart';
 import '../../servizos/servizo_base_datos.dart';
 import '../../servizos/servizo_sincronizacion_p2p.dart';
+import 'revision_pauta.dart';
 
 class CapturaInformeScreen extends StatefulWidget {
   final String? tokenPacienteDestino;
@@ -46,7 +48,20 @@ class _CapturaInformeScreenState extends State<CapturaInformeScreen> {
       _nomeFicheiro = nome;
     });
     try {
-      final analise = await _api.enviarInforme(ficheiro);
+      final analiseExtraida = await _api.enviarInforme(ficheiro);
+      if (!mounted) return;
+      setState(() => _procesando = false);
+      final analise = await Navigator.push<AnaliseModel>(
+        context,
+        MaterialPageRoute(
+          builder: (_) => RevisionPautaScreen(
+            analise: analiseExtraida,
+            paraEnviar: widget.tokenPacienteDestino != null,
+          ),
+        ),
+      );
+      if (analise == null || !mounted) return;
+      setState(() => _procesando = true);
       if (widget.tokenPacienteDestino == null) {
         await DatabaseService().gardarAnalise(analise);
         await P2PSyncService().notificarCoidador('NOVO_INFORME');
@@ -62,8 +77,8 @@ class _CapturaInformeScreenState extends State<CapturaInformeScreen> {
           behavior: SnackBarBehavior.floating,
           backgroundColor: const Color(0xFF268F5A),
           content: Text(widget.tokenPacienteDestino == null
-              ? 'Informe procesado e gardado correctamente'
-              : 'Informe enviado ao paciente correctamente'),
+              ? 'Informe revisado e gardado correctamente'
+              : 'Informe revisado e enviado ao paciente'),
         ),
       );
       Navigator.pop(context, true);

--- a/client/lib/views/camara/revision_pauta.dart
+++ b/client/lib/views/camara/revision_pauta.dart
@@ -1,0 +1,757 @@
+import 'package:flutter/material.dart';
+
+import '../../modelos/analise.dart';
+import '../../modelos/dose_dia.dart';
+import '../../modelos/revision_pauta.dart';
+
+class RevisionPautaScreen extends StatefulWidget {
+  final AnaliseModel analise;
+  final bool paraEnviar;
+
+  const RevisionPautaScreen({
+    super.key,
+    required this.analise,
+    this.paraEnviar = false,
+  });
+
+  @override
+  State<RevisionPautaScreen> createState() => _RevisionPautaScreenState();
+}
+
+class _RevisionPautaScreenState extends State<RevisionPautaScreen> {
+  late AnaliseModel _analise;
+  late AnaliseModel _ultimaRevisionConfirmada;
+  bool _editando = false;
+
+  static const _azul = Colors.blue;
+  static const _verde = Color(0xFF268F5A);
+  static const _fondo = Color(0xFFF8F9FA);
+  static const _escuro = Color(0xFF333333);
+
+  @override
+  void initState() {
+    super.initState();
+    _analise = RevisionPauta.ordenar(widget.analise);
+    _ultimaRevisionConfirmada = _analise;
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+    backgroundColor: _fondo,
+    appBar: AppBar(
+      backgroundColor: _fondo,
+      title: Text(
+        _editando ? 'Corrixir a pauta' : 'Revisar o informe',
+        style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+      ),
+    ),
+    body: SafeArea(
+      child: ListView(
+        padding: const EdgeInsets.fromLTRB(20, 8, 20, 28),
+        children: [
+          _cabecera(),
+          const SizedBox(height: 16),
+          _datosXerais(),
+          const SizedBox(height: 16),
+          _tarxetaPauta(),
+          const SizedBox(height: 16),
+          _proximaVisita(),
+          const SizedBox(height: 18),
+          _accions(),
+        ],
+      ),
+    ),
+  );
+
+  Widget _cabecera() => Container(
+    padding: const EdgeInsets.all(20),
+    decoration: BoxDecoration(
+      color: const Color(0xFFE7F4FF),
+      borderRadius: BorderRadius.circular(20),
+    ),
+    child: Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: 54,
+          height: 54,
+          decoration: const BoxDecoration(color: _azul, shape: BoxShape.circle),
+          child: Icon(
+            _editando ? Icons.edit_outlined : Icons.fact_check_outlined,
+            color: Colors.white,
+            size: 30,
+          ),
+        ),
+        const SizedBox(width: 16),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                _editando
+                    ? 'Corrixe os datos necesarios'
+                    : 'Comproba que a pauta sexa correcta',
+                style: const TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                _editando
+                    ? 'Podes modificar as datas, as doses, os días de control e a seguinte visita.'
+                    : 'A pauta anterior non se substituirá ata que confirmes estes datos.',
+                style: const TextStyle(
+                  fontSize: 15,
+                  height: 1.35,
+                  color: Colors.black54,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    ),
+  );
+
+  Widget _datosXerais() {
+    final c = _analise.cabeceira;
+    final datos = <({IconData icona, String etiqueta, String valor})>[
+      if (_tenValor(c.dataInforme))
+        (
+          icona: Icons.description_outlined,
+          etiqueta: 'Data do informe',
+          valor: c.dataInforme!,
+        ),
+      if (_tenValor(c.farmaco))
+        (
+          icona: Icons.medication_outlined,
+          etiqueta: 'Fármaco',
+          valor: c.farmaco!,
+        ),
+      if (_tenValor(c.inr))
+        (icona: Icons.water_drop_outlined, etiqueta: 'INR', valor: c.inr!),
+      if (_tenValor(c.doseSemanal))
+        (
+          icona: Icons.calendar_view_week_outlined,
+          etiqueta: 'Dose semanal',
+          valor: c.doseSemanal!,
+        ),
+    ];
+    if (datos.isEmpty) return const SizedBox.shrink();
+
+    return _tarxeta(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Datos extraídos',
+            style: TextStyle(fontSize: 19, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 14),
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final ancho = (constraints.maxWidth - 10) / 2;
+              return Wrap(
+                spacing: 10,
+                runSpacing: 10,
+                children: datos
+                    .map(
+                      (dato) => SizedBox(
+                        width: ancho,
+                        child: Container(
+                          padding: const EdgeInsets.all(12),
+                          decoration: BoxDecoration(
+                            color: const Color(0xFFF2F6F8),
+                            borderRadius: BorderRadius.circular(14),
+                          ),
+                          child: Row(
+                            children: [
+                              Icon(dato.icona, color: _azul, size: 23),
+                              const SizedBox(width: 9),
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      dato.etiqueta,
+                                      style: const TextStyle(
+                                        fontSize: 12,
+                                        color: Colors.black54,
+                                      ),
+                                    ),
+                                    const SizedBox(height: 2),
+                                    Text(
+                                      dato.valor,
+                                      maxLines: 2,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: const TextStyle(
+                                        fontSize: 15,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    )
+                    .toList(),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _tarxetaPauta() => _tarxeta(
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            const Expanded(
+              child: Text(
+                'Pauta',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              ),
+            ),
+            Text(
+              '${_analise.calendario.length} días',
+              style: const TextStyle(
+                color: Colors.black54,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 18),
+        if (_editando) _listaEditable() else _gradePauta(),
+      ],
+    ),
+  );
+
+  Widget _gradePauta() => LayoutBuilder(
+    builder: (context, constraints) {
+      final columnas = constraints.maxWidth >= 340 ? 4 : 3;
+      final ancho = (constraints.maxWidth - ((columnas - 1) * 10)) / columnas;
+      return Wrap(
+        spacing: 10,
+        runSpacing: 18,
+        children: _analise.calendario
+            .map((dia) => SizedBox(width: ancho, child: _diaPauta(dia)))
+            .toList(),
+      );
+    },
+  );
+
+  Widget _diaPauta(DoseDiaModel dia) {
+    final dose = dia.eControl ? 'CTRL' : (dia.dose ?? '--');
+    final fondoDose = dia.eControl
+        ? _escuro
+        : dia.dose == '0'
+        ? const Color(0xFFFFD0C8)
+        : const Color(0xFFDDF3EF);
+    return Semantics(
+      label: dia.eControl
+          ? '${dia.diaSemanaTexto}, ${dia.data}, control'
+          : '${dia.diaSemanaTexto}, ${dia.data}, dose ${dia.dose}',
+      child: Column(
+        children: [
+          CircleAvatar(
+            backgroundColor: fondoDose,
+            radius: 28,
+            child: Text(
+              dose,
+              style: TextStyle(
+                color: dia.eControl ? Colors.white : const Color(0xFF167B72),
+                fontSize: 14,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          const SizedBox(height: 7),
+          Text(
+            _nomeDiaCurto(dia.diaSemanaTexto),
+            style: const TextStyle(fontSize: 13, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            _dataCurta(dia.data),
+            style: const TextStyle(fontSize: 11, color: Colors.black45),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _listaEditable() => Column(
+    children: List.generate(_analise.calendario.length, (indice) {
+      final dia = _analise.calendario[indice];
+      return Padding(
+        padding: EdgeInsets.only(
+          bottom: indice == _analise.calendario.length - 1 ? 0 : 12,
+        ),
+        child: Container(
+          padding: const EdgeInsets.all(14),
+          decoration: BoxDecoration(
+            color: const Color(0xFFF6F8FA),
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: const Color(0xFFE1E4E8)),
+          ),
+          child: Column(
+            children: [
+              Row(
+                children: [
+                  CircleAvatar(
+                    backgroundColor: dia.eControl
+                        ? _escuro
+                        : const Color(0xFFDDF3EF),
+                    child: Text(
+                      dia.eControl ? 'C' : (dia.dose ?? '--'),
+                      style: TextStyle(
+                        color: dia.eControl
+                            ? Colors.white
+                            : const Color(0xFF167B72),
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: InkWell(
+                      borderRadius: BorderRadius.circular(12),
+                      onTap: () => _escollerDataDia(indice),
+                      child: InputDecorator(
+                        decoration: const InputDecoration(
+                          labelText: 'Data',
+                          border: OutlineInputBorder(),
+                          suffixIcon: Icon(Icons.calendar_today_outlined),
+                        ),
+                        child: Text(
+                          _dataVisible(dia.data),
+                          style: const TextStyle(fontSize: 16),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 10),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: dia.eControl
+                          ? null
+                          : () => _escollerDose(indice),
+                      icon: const Icon(Icons.medication_outlined),
+                      label: Text(
+                        dia.eControl ? 'Sen dose' : 'Dose: ${dia.dose ?? '--'}',
+                      ),
+                      style: OutlinedButton.styleFrom(
+                        minimumSize: const Size.fromHeight(48),
+                        alignment: Alignment.centerLeft,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Column(
+                    children: [
+                      const Text(
+                        'Control',
+                        style: TextStyle(fontSize: 12, color: Colors.black54),
+                      ),
+                      Switch(
+                        value: dia.eControl,
+                        activeThumbColor: _verde,
+                        onChanged: (valor) => setState(() {
+                          _analise = RevisionPauta.actualizarDia(
+                            _analise,
+                            indice,
+                            eControl: valor,
+                          );
+                        }),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      );
+    }),
+  );
+
+  Widget _proximaVisita() {
+    final visita = _analise.cabeceira.proximaVisita;
+    return _tarxeta(
+      child: Row(
+        children: [
+          Container(
+            width: 52,
+            height: 52,
+            decoration: BoxDecoration(
+              color: const Color(0xFFE7F4FF),
+              borderRadius: BorderRadius.circular(15),
+            ),
+            child: const Icon(Icons.event_outlined, color: _azul, size: 29),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Seguinte visita',
+                  style: TextStyle(fontSize: 14, color: Colors.black54),
+                ),
+                const SizedBox(height: 3),
+                Text(
+                  _tenValor(visita)
+                      ? _dataVisible(visita!)
+                      : 'Non identificada',
+                  style: const TextStyle(
+                    fontSize: 19,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                if (_tenValor(_analise.cabeceira.centro)) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    _analise.cabeceira.centro!,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: Colors.blueGrey,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          if (_editando)
+            IconButton.filledTonal(
+              tooltip: 'Corrixir a seguinte visita',
+              onPressed: _escollerProximaVisita,
+              icon: const Icon(Icons.edit_calendar_outlined),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _accions() {
+    if (_editando) {
+      return Column(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(14),
+            decoration: BoxDecoration(
+              color: const Color(0xFFFFF7E0),
+              borderRadius: BorderRadius.circular(14),
+            ),
+            child: const Row(
+              children: [
+                Icon(Icons.info_outline, color: Color(0xFF9A6A00)),
+                SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    'Ao rematar volverás á revisión para comprobar as correccións.',
+                    style: TextStyle(fontSize: 14, height: 1.3),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 14),
+          ElevatedButton.icon(
+            onPressed: _revisarCorreccions,
+            icon: const Icon(Icons.visibility_outlined),
+            label: const Text('Revisar correccións'),
+            style: _estiloBotonPrincipal(_verde),
+          ),
+          const SizedBox(height: 10),
+          TextButton(
+            onPressed: () => setState(() {
+              _analise = _ultimaRevisionConfirmada;
+              _editando = false;
+            }),
+            child: const Text(
+              'Cancelar os cambios',
+              style: TextStyle(fontSize: 16),
+            ),
+          ),
+        ],
+      );
+    }
+
+    return _tarxeta(
+      child: Column(
+        children: [
+          const Icon(Icons.help_outline, color: _azul, size: 38),
+          const SizedBox(height: 8),
+          const Text(
+            'Está todo correcto?',
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 6),
+          const Text(
+            'Confirma especialmente as datas e as doses antes de continuar.',
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: 15, height: 1.35, color: Colors.black54),
+          ),
+          const SizedBox(height: 18),
+          ElevatedButton.icon(
+            onPressed: _confirmar,
+            icon: const Icon(Icons.check_circle_outline),
+            label: Text(
+              widget.paraEnviar
+                  ? 'Si, confirmar e enviar'
+                  : 'Si, confirmar e gardar',
+            ),
+            style: _estiloBotonPrincipal(_verde),
+          ),
+          const SizedBox(height: 10),
+          OutlinedButton.icon(
+            onPressed: () => setState(() {
+              _ultimaRevisionConfirmada = _analise;
+              _editando = true;
+            }),
+            icon: const Icon(Icons.edit_outlined),
+            label: const Text('Non, corrixir datos'),
+            style: OutlinedButton.styleFrom(
+              foregroundColor: _escuro,
+              minimumSize: const Size(double.infinity, 54),
+              side: const BorderSide(color: _escuro, width: 1.3),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              textStyle: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  ButtonStyle _estiloBotonPrincipal(Color cor) => ElevatedButton.styleFrom(
+    backgroundColor: cor,
+    foregroundColor: Colors.white,
+    minimumSize: const Size(double.infinity, 56),
+    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+    textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+  );
+
+  Widget _tarxeta({required Widget child}) => Container(
+    width: double.infinity,
+    padding: const EdgeInsets.all(18),
+    decoration: BoxDecoration(
+      color: Colors.white,
+      borderRadius: BorderRadius.circular(20),
+      boxShadow: const [
+        BoxShadow(
+          color: Color(0x12000000),
+          blurRadius: 12,
+          offset: Offset(0, 4),
+        ),
+      ],
+    ),
+    child: child,
+  );
+
+  Future<void> _escollerDataDia(int indice) async {
+    final actual =
+        RevisionPauta.interpretarData(_analise.calendario[indice].data) ??
+        DateTime.now();
+    final nova = await showDatePicker(
+      context: context,
+      initialDate: actual,
+      firstDate: DateTime(2000),
+      lastDate: DateTime(2100),
+      helpText: 'Selecciona a data da dose',
+      cancelText: 'Cancelar',
+      confirmText: 'Aceptar',
+    );
+    if (nova == null || !mounted) return;
+    setState(
+      () =>
+          _analise = RevisionPauta.actualizarDia(_analise, indice, data: nova),
+    );
+  }
+
+  Future<void> _escollerProximaVisita() async {
+    final ultimaData = _analise.calendario.isEmpty
+        ? null
+        : RevisionPauta.interpretarData(_analise.calendario.last.data);
+    final actual =
+        RevisionPauta.interpretarData(_analise.cabeceira.proximaVisita) ??
+        ultimaData ??
+        DateTime.now();
+    final nova = await showDatePicker(
+      context: context,
+      initialDate: actual,
+      firstDate: DateTime(2000),
+      lastDate: DateTime(2100),
+      helpText: 'Selecciona a seguinte visita',
+      cancelText: 'Cancelar',
+      confirmText: 'Aceptar',
+    );
+    if (nova == null || !mounted) return;
+    setState(
+      () => _analise = RevisionPauta.actualizarProximaVisita(_analise, nova),
+    );
+  }
+
+  Future<void> _escollerDose(int indice) async {
+    final actual = _analise.calendario[indice].dose ?? '';
+    final controlador = TextEditingController(text: actual);
+    const habituais = ['0', '1/4', '1/2', '3/4', '1', '1+1/4', '1+1/2'];
+    final novaDose = await showModalBottomSheet<String>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (context) => SafeArea(
+        child: Padding(
+          padding: EdgeInsets.fromLTRB(
+            20,
+            4,
+            20,
+            20 + MediaQuery.viewInsetsOf(context).bottom,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'Corrixir a dose',
+                style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 6),
+              const Text('Escolle unha dose habitual ou escribe outro valor.'),
+              const SizedBox(height: 16),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: habituais
+                    .map(
+                      (dose) => ActionChip(
+                        label: Text(
+                          dose,
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
+                        backgroundColor: dose == actual
+                            ? const Color(0xFFDDF3EF)
+                            : null,
+                        onPressed: () => Navigator.pop(context, dose),
+                      ),
+                    )
+                    .toList(),
+              ),
+              const SizedBox(height: 18),
+              TextField(
+                controller: controlador,
+                keyboardType: TextInputType.text,
+                textInputAction: TextInputAction.done,
+                decoration: const InputDecoration(
+                  labelText: 'Outra dose',
+                  hintText: 'Ex.: 1/2',
+                  border: OutlineInputBorder(),
+                ),
+                onSubmitted: (valor) => Navigator.pop(context, valor.trim()),
+              ),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: () =>
+                    Navigator.pop(context, controlador.text.trim()),
+                style: _estiloBotonPrincipal(_escuro),
+                child: const Text('Aplicar dose'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    controlador.dispose();
+    if (novaDose == null || !mounted) return;
+    setState(
+      () => _analise = RevisionPauta.actualizarDia(
+        _analise,
+        indice,
+        dose: novaDose,
+      ),
+    );
+  }
+
+  void _revisarCorreccions() {
+    final erros = RevisionPauta.validar(_analise);
+    if (erros.isNotEmpty) {
+      _mostrarErro(erros.first);
+      return;
+    }
+    setState(() {
+      _analise = RevisionPauta.ordenar(_analise);
+      _ultimaRevisionConfirmada = _analise;
+      _editando = false;
+    });
+  }
+
+  void _confirmar() {
+    final erros = RevisionPauta.validar(_analise);
+    if (erros.isNotEmpty) {
+      _mostrarErro(erros.first);
+      return;
+    }
+    Navigator.pop(context, RevisionPauta.ordenar(_analise));
+  }
+
+  void _mostrarErro(String mensaxe) =>
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          behavior: SnackBarBehavior.floating,
+          backgroundColor: Colors.red.shade700,
+          content: Text(mensaxe),
+        ),
+      );
+
+  bool _tenValor(String? valor) => valor?.trim().isNotEmpty == true;
+
+  String _nomeDiaCurto(String nome) {
+    final limpo = nome.trim();
+    return limpo.length <= 3 ? limpo : limpo.substring(0, 3);
+  }
+
+  String _dataCurta(String valor) {
+    final data = RevisionPauta.interpretarData(valor);
+    if (data == null) return valor;
+    const meses = [
+      'Xan',
+      'Feb',
+      'Mar',
+      'Abr',
+      'Mai',
+      'Xuñ',
+      'Xul',
+      'Ago',
+      'Set',
+      'Out',
+      'Nov',
+      'Dec',
+    ];
+    return '${data.day.toString().padLeft(2, '0')} ${meses[data.month - 1]}';
+  }
+
+  String _dataVisible(String valor) {
+    final data = RevisionPauta.interpretarData(valor);
+    return data == null ? valor : RevisionPauta.formatoVisita(data);
+  }
+}

--- a/client/lib/views/camara/revision_pauta.dart
+++ b/client/lib/views/camara/revision_pauta.dart
@@ -338,6 +338,14 @@ class _RevisionPautaScreenState extends State<RevisionPautaScreen> {
                       ),
                     ),
                   ),
+                  const SizedBox(width: 6),
+                  IconButton(
+                    key: ValueKey('eliminar-dia-$indice'),
+                    tooltip: 'Eliminar este día',
+                    onPressed: () => _eliminarDia(indice),
+                    color: Colors.red.shade700,
+                    icon: const Icon(Icons.delete_outline),
+                  ),
                 ],
               ),
               const SizedBox(height: 10),
@@ -551,6 +559,33 @@ class _RevisionPautaScreenState extends State<RevisionPautaScreen> {
     shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
     textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
   );
+
+  void _eliminarDia(int indice) {
+    final eliminado = _analise.calendario[indice];
+    setState(() {
+      _analise = RevisionPauta.eliminarDia(_analise, indice);
+    });
+
+    final mensaxeiro = ScaffoldMessenger.of(context);
+    mensaxeiro
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: const Text('Eliminouse a fila da pauta.'),
+          action: SnackBarAction(
+            label: 'Desfacer',
+            onPressed: () => setState(() {
+              final posicion = indice.clamp(0, _analise.calendario.length);
+              _analise = RevisionPauta.inserirDia(
+                _analise,
+                posicion,
+                eliminado,
+              );
+            }),
+          ),
+        ),
+      );
+  }
 
   Widget _tarxeta({required Widget child}) => Container(
     width: double.infinity,

--- a/client/test/modelos/revision_pauta_test.dart
+++ b/client/test/modelos/revision_pauta_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tfg_sintrom/modelos/analise.dart';
+import 'package:tfg_sintrom/modelos/cabeceira.dart';
+import 'package:tfg_sintrom/modelos/dose_dia.dart';
+import 'package:tfg_sintrom/modelos/revision_pauta.dart';
+
+void main() {
+  AnaliseModel analiseValida() => AnaliseModel(
+    cabeceira: CabeceiraModel(
+      dataInforme: '2026-08-07',
+      farmaco: 'Sintrom 4 mg',
+      proximaVisita: '12/08/2026',
+    ),
+    calendario: [
+      DoseDiaModel(
+        data: '2026-08-08',
+        dia: 8,
+        dose: '1/2',
+        accion: 'TOMAR',
+        eControl: false,
+        diaSemanaTexto: 'SÁBADO',
+      ),
+      DoseDiaModel(
+        data: '2026-08-12',
+        dia: 12,
+        dose: null,
+        accion: 'CONTROL',
+        eControl: true,
+        diaSemanaTexto: 'MÉRCORES',
+      ),
+    ],
+    historico: const [],
+  );
+
+  test('acepta unha pauta coherente', () {
+    expect(RevisionPauta.validar(analiseValida()), isEmpty);
+  });
+
+  test('rexeita datas repetidas e doses baleiras', () {
+    final base = analiseValida();
+    final incorrecta = AnaliseModel(
+      cabeceira: base.cabeceira,
+      calendario: [
+        base.calendario.first,
+        DoseDiaModel(
+          data: '2026-08-08',
+          dia: 8,
+          dose: '',
+          accion: 'TOMAR',
+          eControl: false,
+          diaSemanaTexto: 'SÁBADO',
+        ),
+      ],
+      historico: const [],
+    );
+
+    final erros = RevisionPauta.validar(incorrecta);
+    expect(erros, contains('A data 2026-08-08 está repetida.'));
+    expect(erros, contains('Falta a dose do 2026-08-08.'));
+  });
+
+  test('actualiza a data e os campos derivados do día', () {
+    final actualizada = RevisionPauta.actualizarDia(
+      analiseValida(),
+      0,
+      data: DateTime(2026, 8, 10),
+      dose: '0',
+    );
+
+    final dia = actualizada.calendario.first;
+    expect(dia.data, '2026-08-10');
+    expect(dia.dia, 10);
+    expect(dia.diaSemanaTexto, 'LUNS');
+    expect(dia.accion, 'NON TOMAR');
+  });
+
+  test('un día de control non conserva unha dose', () {
+    final actualizada = RevisionPauta.actualizarDia(
+      analiseValida(),
+      0,
+      eControl: true,
+    );
+
+    final dia = actualizada.calendario.first;
+    expect(dia.eControl, isTrue);
+    expect(dia.dose, isNull);
+    expect(dia.accion, 'CONTROL');
+  });
+}

--- a/client/test/views/revision_pauta_test.dart
+++ b/client/test/views/revision_pauta_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tfg_sintrom/modelos/analise.dart';
+import 'package:tfg_sintrom/modelos/cabeceira.dart';
+import 'package:tfg_sintrom/modelos/dose_dia.dart';
+import 'package:tfg_sintrom/views/camara/revision_pauta.dart';
+
+void main() {
+  testWidgets('comeza en revisión e só edita cando o usuario o solicita', (
+    tester,
+  ) async {
+    final analise = AnaliseModel(
+      cabeceira: CabeceiraModel(
+        dataInforme: '2026-08-07',
+        inr: '2.5',
+        farmaco: 'Sintrom 4 mg',
+        doseSemanal: '3,5 mg',
+        proximaVisita: '12/08/2026',
+      ),
+      calendario: [
+        DoseDiaModel(
+          data: '2026-08-08',
+          dia: 8,
+          dose: '1/2',
+          accion: 'TOMAR',
+          eControl: false,
+          diaSemanaTexto: 'SÁBADO',
+        ),
+      ],
+      historico: const [],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(home: RevisionPautaScreen(analise: analise)),
+    );
+
+    await tester.scrollUntilVisible(
+      find.text('Está todo correcto?'),
+      350,
+      scrollable: find.byType(Scrollable).first,
+    );
+    expect(find.text('Está todo correcto?'), findsOneWidget);
+    expect(find.text('Si, confirmar e gardar'), findsOneWidget);
+    expect(find.text('Non, corrixir datos'), findsOneWidget);
+    expect(find.text('Revisar correccións'), findsNothing);
+
+    await tester.ensureVisible(find.text('Non, corrixir datos'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Non, corrixir datos'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Corrixir a pauta'), findsOneWidget);
+    await tester.scrollUntilVisible(
+      find.text('Dose: 1/2'),
+      -300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    expect(find.text('Dose: 1/2'), findsOneWidget);
+    expect(find.text('Revisar correccións'), findsOneWidget);
+    expect(find.text('Está todo correcto?'), findsNothing);
+  });
+}

--- a/client/test/views/revision_pauta_test.dart
+++ b/client/test/views/revision_pauta_test.dart
@@ -59,4 +59,59 @@ void main() {
     expect(find.text('Revisar correccións'), findsOneWidget);
     expect(find.text('Está todo correcto?'), findsNothing);
   });
+
+  testWidgets('permite eliminar unha fila extraída de máis e desfacelo', (
+    tester,
+  ) async {
+    final analise = AnaliseModel(
+      cabeceira: CabeceiraModel(proximaVisita: '13/08/2026'),
+      calendario: [
+        DoseDiaModel(
+          data: '2026-08-13',
+          dia: 13,
+          dose: null,
+          accion: 'CONTROL',
+          eControl: true,
+          diaSemanaTexto: 'XOVES',
+        ),
+        DoseDiaModel(
+          data: '2026-08-13',
+          dia: 13,
+          dose: '0',
+          accion: 'NON TOMAR',
+          eControl: false,
+          diaSemanaTexto: 'XOVES',
+        ),
+      ],
+      historico: const [],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(home: RevisionPautaScreen(analise: analise)),
+    );
+    await tester.scrollUntilVisible(
+      find.text('Non, corrixir datos'),
+      350,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.ensureVisible(find.text('Non, corrixir datos'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Non, corrixir datos'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('eliminar-dia-1')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('eliminar-dia-1')));
+    await tester.pump();
+
+    expect(find.byTooltip('Eliminar este día'), findsOneWidget);
+    expect(find.text('Eliminouse a fila da pauta.'), findsOneWidget);
+
+    final accionDesfacer = tester.widget<SnackBarAction>(
+      find.byType(SnackBarAction),
+    );
+    accionDesfacer.onPressed();
+    await tester.pump();
+    expect(find.byTooltip('Eliminar este día'), findsNWidgets(2));
+  });
 }


### PR DESCRIPTION
## Resumo

- Engade unha pantalla de revisión non editable antes de gardar ou enviar unha pauta extraída.
- Mantén o estilo da aplicación mediante tarxetas, círculos de dose, cores azuis e verdes e textos accesibles.
- Mostra os datos xerais principais, a pauta completa e a seguinte visita.
- Pregunta explicitamente se todo é correcto antes de continuar.
- Activa a edición só ao escoller «Non, corrixir datos».
- Permite corrixir datas, doses, días de control e a seguinte visita.
- Volve á vista de revisión despois das correccións para solicitar unha confirmación final.
- Aplica o mesmo fluxo cando o coidador procesa unha folla para un paciente.

## Integridade dos datos

- A pauta anterior non se substitúe se se cancela a revisión.
- Non se aceptan datas inválidas ou repetidas.
- Os días de toma requiren unha dose válida.
- Os días de control non conservan unha dose.
- Os campos derivados da data actualízanse automaticamente.
- O gardado local ou o envío P2P só comezan despois da confirmación.

## Comprobacións

- `flutter analyze`
- `flutter test test/modelos/revision_pauta_test.dart test/views/revision_pauta_test.dart` — 5 probas superadas
- `flutter build apk --debug`

Closes #28